### PR TITLE
Supports error estimations by default using the Subsampling technique

### DIFF
--- a/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
+++ b/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
@@ -861,7 +861,8 @@ mathematical_function_expression
     ;
 
 unary_mathematical_function
-    : ROUND | FLOOR | CEIL | EXP | LN | LOG10 | LOG2 | SIN | COS | TAN | SIGN | RAND
+    : ROUND | FLOOR | CEIL | EXP | LN | LOG10 | LOG2 | SIN | COS | TAN | SIGN | RAND | FNV_HASH | ABS
+    | STDDEV | SQRT
     ;
     
 noparam_mathematical_function
@@ -1373,6 +1374,7 @@ WRITETEXT:                       W R I T E T E X T;
 
 // Additional keywords (they can be id).
 ABSOLUTE:                        A B S O L U T E;
+ABS:                             A B S;
 APPLY:                           A P P L Y;
 AUTO:                            A U T O;
 AVG:                             A V G;
@@ -1409,6 +1411,7 @@ FIRST:                           F I R S T;
 FLOOR:                           F L O O R;
 FOLLOWING:                       F O L L O W I N G;
 FORWARD_ONLY:                    F O R W A R D '_' O N L Y;
+FNV_HASH:                        F N V '_' H A S H;
 FULLSCAN:                        F U L L S C A N;
 GLOBAL:                          G L O B A L;
 GO:                              G O;
@@ -1485,8 +1488,10 @@ SPATIAL_WINDOW_MAX_CELLS:        S P A T I A L '_' W I N D O W '_' M A X '_' C E
 STATIC:                          S T A T I C;
 STATS_STREAM:                    S T A T S '_' S T R E A M;
 STDEV:                           S T D E V;
+STDDEV:                          S T D D E V;
 STDEVP:                          S T D E V P;
 SUM:                             S U M;
+SQRT:                            S Q R T;
 TAN:                             T A N;
 THROW:                           T H R O W;
 TIES:                            T I E S;

--- a/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
+++ b/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
@@ -856,17 +856,24 @@ ranking_windowed_function
     ;
 
 mathematical_function_expression
-    : unary_mathematical_function '(' expression ')'
-    | noparam_mathematical_function '(' ')'
+    : unary_mathematical_function
+    | noparam_mathematical_function
+    | binary_mathematical_function
+    ;
+
+binary_mathematical_function
+    : function_name=MOD
+      '(' expression ',' expression ')'
     ;
 
 unary_mathematical_function
-    : ROUND | FLOOR | CEIL | EXP | LN | LOG10 | LOG2 | SIN | COS | TAN | SIGN | RAND | FNV_HASH | ABS
-    | STDDEV | SQRT
+    : function_name=(ROUND | FLOOR | CEIL | EXP | LN | LOG10 | LOG2 | SIN | COS | TAN | SIGN | RAND | FNV_HASH | ABS | STDDEV | SQRT)
+      '(' expression ')'
     ;
     
 noparam_mathematical_function
-    : UNIX_TIMESTAMP
+    : function_name=UNIX_TIMESTAMP
+      '(' ')'
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms173454.aspx
@@ -1437,6 +1444,7 @@ MARK:                            M A R K;
 MAX:                             M A X;
 MIN:                             M I N;
 MIN_ACTIVE_ROWVERSION:           M I N '_' A C T I V E '_' R O W V E R S I O N;
+MOD:                             M O D;
 MODIFY:                          M O D I F Y;
 NEXT:                            N E X T;
 NAME:                            N A M E;

--- a/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
+++ b/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
@@ -859,16 +859,23 @@ mathematical_function_expression
     : unary_mathematical_function
     | noparam_mathematical_function
     | binary_mathematical_function
+    | ternary_mathematical_function
+    ;
+    
+ternary_mathematical_function
+    : function_name=(CONV | SUBSTR)
+      '(' expression ',' expression ',' expression ')'
     ;
 
 binary_mathematical_function
-    : function_name=MOD
+    : function_name=(MOD | PMOD)
       '(' expression ',' expression ')'
     ;
 
 unary_mathematical_function
-    : function_name=(ROUND | FLOOR | CEIL | EXP | LN | LOG10 | LOG2 | SIN | COS | TAN | SIGN | RAND | FNV_HASH | ABS | STDDEV | SQRT)
+    : function_name=(ROUND | FLOOR | CEIL | EXP | LN | LOG10 | LOG2 | SIN | COS | TAN | SIGN | RAND | FNV_HASH | ABS | STDDEV | SQRT | MD5)
       '(' expression ')'
+    | function_name=CAST '(' cast_as_expression ')'
     ;
     
 noparam_mathematical_function
@@ -896,6 +903,10 @@ aggregate_windowed_function
 
 all_distinct_expression
     : (ALL | DISTINCT)? expression
+    ;
+    
+cast_as_expression
+    : expression AS data_type
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms189461.aspx
@@ -1057,7 +1068,7 @@ sign
 
 // https://msdn.microsoft.com/en-us/library/ms175874.aspx
 id
-    : ID
+    : simple_id
     | DOUBLE_QUOTE_ID
     | SQUARE_BRACKET_ID
     | BACKTICK_ID
@@ -1219,6 +1230,7 @@ CONSTRAINT:                      C O N S T R A I N T;
 CONTAINS:                        C O N T A I N S;
 CONTAINSTABLE:                   C O N T A I N S T A B L E;
 CONTINUE:                        C O N T I N U E;
+CONV:                            C O N V;
 CONVERT:                         C O N V E R T;
 CREATE:                          C R E A T E;
 CROSS:                           C R O S S;
@@ -1346,6 +1358,7 @@ SET:                             S E T;
 SETUSER:                         S E T U S E R;
 SHUTDOWN:                        S H U T D O W N;
 SOME:                            S O M E;
+SUBSTR:                          S U B S T R;
 STATISTICS:                      S T A T I S T I C S;
 SYSTEM_USER:                     S Y S T E M '_' U S E R;
 TABLE:                           T A B L E;
@@ -1442,6 +1455,7 @@ LOGIN:                           L O G I N;
 LOOP:                            L O O P;
 MARK:                            M A R K;
 MAX:                             M A X;
+MD5:                             M D '5';
 MIN:                             M I N;
 MIN_ACTIVE_ROWVERSION:           M I N '_' A C T I V E '_' R O W V E R S I O N;
 MOD:                             M O D;
@@ -1463,6 +1477,7 @@ OUTPUT:                          O U T P U T;
 OWNER:                           O W N E R;
 PARTITION:                       P A R T I T I O N;
 PATH:                            P A T H;
+PMOD:                            P M O D;
 PRECEDING:                       P R E C E D I N G;
 PRIOR:                           P R I O R;
 QUOTED_BY:                       Q U O T E D ' ' B Y;

--- a/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
+++ b/core/src/main/antlr4/edu/umich/verdict/VerdictSQL.g4
@@ -890,7 +890,7 @@ aggregate_windowed_function
     | VAR '(' all_distinct_expression ')' over_clause?
     | VARP '(' all_distinct_expression ')' over_clause?
     | COUNT '(' ('*' | all_distinct_expression) ')' over_clause?
-    | NDV '(' ('*' | all_distinct_expression) ')' over_clause?
+    | NDV '(' all_distinct_expression ')' over_clause?
     | COUNT_BIG '(' ('*' | all_distinct_expression) ')' over_clause?
     ;
 

--- a/core/src/main/java/edu/umich/verdict/VerdictConf.java
+++ b/core/src/main/java/edu/umich/verdict/VerdictConf.java
@@ -24,11 +24,19 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Scanner;
 
+import com.google.common.collect.ImmutableMap;
+
 import edu.umich.verdict.util.VerdictLogger;
 
 public class VerdictConf {
 	
     private HashMap<String, String> configs = new HashMap<String, String>();
+    
+    private final Map<String, String> configKeySynonyms =
+    		new ImmutableMap.Builder<String, String>()
+    		.put("byapss", "verdict.bypass")
+    		.put("loglevel", "verdict.loglevel")
+    		.build();
     
     public VerdictConf() {
         setDefaults();
@@ -96,6 +104,9 @@ public class VerdictConf {
     }
 
     public String get(String key) {
+    	if (configKeySynonyms.containsKey(key)) {
+    		return get(configKeySynonyms.get(key));
+    	}
     	return configs.get(key.toLowerCase());
     }
     
@@ -119,7 +130,11 @@ public class VerdictConf {
     }
 
     public VerdictConf set(String key, String value) {
-    	if (key.equals("log4j.loglevel")) {
+    	if (configKeySynonyms.containsKey(key)) {
+    		return set(configKeySynonyms.get(key), value);
+    	}
+    	
+    	if (key.equals("verdict.loglevel")) {
     		VerdictLogger.setLogLevel(value);
     	}
         configs.put(key.toLowerCase(), value);

--- a/core/src/main/java/edu/umich/verdict/VerdictContext.java
+++ b/core/src/main/java/edu/umich/verdict/VerdictContext.java
@@ -69,12 +69,14 @@ public class VerdictContext {
 								(conf.getBoolean("no_user_password"))? "" : conf.getUser(),
 								(conf.getBoolean("no_user_password"))? "" : conf.getPassword(),
 								conf.get(conf.getDbms() + ".jdbc_class_name"));
-		VerdictLogger.info( 
-				(conf.getDbmsSchema() != null) ?
-						String.format("Connected to database: %s//%s:%s/%s",
-								conf.getDbms(), conf.getHost(), conf.getPort(), conf.getDbmsSchema())
-						: String.format("Connected to database: %s//%s:%s",
-								conf.getDbms(), conf.getHost(), conf.getPort()));
+		if (!conf.getDbms().equals("dummy")) {
+			VerdictLogger.info(
+					(conf.getDbmsSchema() != null) ?
+							String.format("Connected to database: %s//%s:%s/%s",
+									conf.getDbms(), conf.getHost(), conf.getPort(), conf.getDbmsSchema())
+							: String.format("Connected to database: %s//%s:%s",
+									conf.getDbms(), conf.getHost(), conf.getPort()));
+		}
 		
 		metaDbms = dbms;
 		meta = new VerdictMeta(this);		// this must be called after DB connection is created.

--- a/core/src/main/java/edu/umich/verdict/VerdictContext.java
+++ b/core/src/main/java/edu/umich/verdict/VerdictContext.java
@@ -140,8 +140,5 @@ public class VerdictContext {
 	public long getCurrentQid() {
 		return queryUid;
 	}
-	
-	public String samplingProbColName() {
-		return ST_SAMPLING_PROB_COL;
-	}
+
 }

--- a/core/src/main/java/edu/umich/verdict/VerdictMeta.java
+++ b/core/src/main/java/edu/umich/verdict/VerdictMeta.java
@@ -154,6 +154,7 @@ public class VerdictMeta {
 				tableToColumnNames.get(tableUName).add(tabCol.getRight());
 			}
 			
+			sampleNameMeta.clear();
 			if (tableToColumnNames.containsKey(metaNameTable)) {
 				// sample name
 				rs = SingleRelation.from(vc, metaNameTable)
@@ -180,6 +181,7 @@ public class VerdictMeta {
 				rs.close();
 			}
 
+			sampleSizeMeta.clear();
 			if (tableToColumnNames.containsKey(metaSizeTable)) {
 				// sample size
 				rs = SingleRelation.from(vc, metaSizeTable)
@@ -239,6 +241,9 @@ public class VerdictMeta {
 	
 	public SampleSizeInfo getSampleSizeOf(SampleParam param) {
 		TableUniqueName sampleTable = lookForSampleTable(param);
+		if (sampleTable == null) {
+			return null;
+		}
 		return vc.getMeta().getSampleSizeOf(sampleTable);
 	}
 	
@@ -268,8 +273,13 @@ public class VerdictMeta {
 				VerdictLogger.error(this, String.format("No %.2f%% %s sample table on %s found for the table %s.",
 						param.samplingRatio*100, param.sampleType, param.columnNames.toString(), originalTable));
 			} else if (param.sampleType.equals("uniform")) {
-				VerdictLogger.error(this, String.format("No %.2f%% %s sample table found for the table %s.",
-						param.samplingRatio*100, param.sampleType, originalTable));
+				if (param.samplingRatio != null) {
+					VerdictLogger.error(this, String.format("No %.2f%% %s sample table found for the table %s.",
+							param.samplingRatio*100, param.sampleType, originalTable));
+				} else {
+					VerdictLogger.error(this, String.format("No %s sample table found for the table %s.",
+							param.sampleType, originalTable));
+				}
 			}
 		}
 		

--- a/core/src/main/java/edu/umich/verdict/VerdictMeta.java
+++ b/core/src/main/java/edu/umich/verdict/VerdictMeta.java
@@ -58,8 +58,8 @@ public class VerdictMeta {
 	
 	public VerdictMeta(VerdictContext vc) throws VerdictException {
 		this.vc = vc;
-		META_NAME_TABLE = vc.getConf().get("meta_name_table");
-		META_SIZE_TABLE = vc.getConf().get("meta_size_table");
+		META_NAME_TABLE = vc.getConf().get("verdict.meta_name_table");
+		META_SIZE_TABLE = vc.getConf().get("verdict.meta_size_table");
 		sampleSizeMeta = new HashMap<TableUniqueName, SampleSizeInfo>();
 		sampleNameMeta = new HashMap<TableUniqueName, Map<SampleParam, TableUniqueName>>();
 		uptodateSchemas = new HashSet<Pair<Long, String>>();

--- a/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
@@ -342,7 +342,9 @@ public class Dbms {
 	 */
 	public ExactRelation augmentWithRandomPartitionNum(ExactRelation r) {
 		int pcount = partitionCount();
-		return r.select("*, " + String.format("mod(rand() * %d, %d) AS %s", pcount, pcount, partitionColumnName()));
+		ExactRelation aug = r.select("*, " + String.format("mod(rand() * %d, %d) AS %s", pcount, pcount, partitionColumnName()));
+		aug.setAliasName(r.getAliasName());
+		return aug;
 	}
 
 	public void close() throws VerdictException {

--- a/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
@@ -562,4 +562,8 @@ public class Dbms {
 	public String samplingProbabilityColumnName() {
 		return vc.getConf().get("verdict.sampling_probability_column");
 	}
+	
+	protected String quote(String expr) {
+		return String.format("\"%s\"", expr);
+	}
 }

--- a/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
@@ -551,4 +551,8 @@ public class Dbms {
 	public int partitionCount() {
 		return vc.getConf().getInt("verdict.subsampling_partition_count");
 	}
+
+	public String samplingProbabilityColumnName() {
+		return vc.getConf().get("verdict.sampling_probability_column");
+	}
 }

--- a/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
@@ -5,6 +5,7 @@ import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.datatypes.VerdictResultSet;
 import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.ExactRelation;
 import edu.umich.verdict.relation.SingleRelation;
 import edu.umich.verdict.util.StackTraceReader;
 import edu.umich.verdict.util.VerdictLogger;
@@ -333,6 +334,16 @@ public class Dbms {
 	public Connection getDbmsConnection() {
 		return conn;
 	}
+	
+	/**
+	 * Attach a new column in which random integers between 0 and partitionCount-1 (inclusive) are populated. 
+	 * @param partitionCount
+	 * @return
+	 */
+	public ExactRelation augmentWithRandomPartitionNum(ExactRelation r) {
+		int pcount = partitionCount();
+		return r.select("*, " + String.format("mod(rand() * %d, %d) AS %s", pcount, pcount, partitionColumnName()));
+	}
 
 	public void close() throws VerdictException {
 		try {
@@ -533,7 +544,11 @@ public class Dbms {
 		return "STDDEV";
 	}
 
-	protected String partitionColumnName() {
-		return vc.getConf().get("verdict.partition_column_name");
+	public String partitionColumnName() {
+		return vc.getConf().get("verdict.subsampling_partition_column_name");
+	}
+	
+	public int partitionCount() {
+		return vc.getConf().getInt("verdict.subsampling_partition_count");
 	}
 }

--- a/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/Dbms.java
@@ -307,12 +307,17 @@ public class Dbms {
 		TableUniqueName sampleTableName = param.sampleTableName();
 		String sql = String.format("CREATE TABLE %s AS ", sampleTableName) + 
 				 	 SingleRelation.from(vc, param.originalTable)
-				 	 .where(String.format("mod(cast(conv(substr(md5(%s),17,32),16,10) as unsigned), 10000) <= %.4f", param.columnNames.get(0), param.samplingRatio*10000))
+				 	 .where(modOfHash(param.columnNames.get(0), 10000)
+				 			 + String.format(" <= %.4f", param.samplingRatio*10000))
 				 	 .select("*, round(rand()*100)%100 AS " + partitionColumnName()).toSql();
 		
 		VerdictLogger.debug(this, String.format("Creates a table: %s", sql));
 		this.executeUpdate(sql);
 		VerdictLogger.debug(this, "Done.");
+	}
+	
+	public String modOfHash(String col, int mod) {
+		return String.format("mod(cast(conv(substr(md5(%s),17,32),16,10) as unsigned), %d)", col, mod);
 	}
 	
 	public Pair<Long, Long> createUniverseSampleTableOf(SampleParam param) throws VerdictException {

--- a/core/src/main/java/edu/umich/verdict/dbms/DbmsHive.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/DbmsHive.java
@@ -10,6 +10,8 @@ import edu.umich.verdict.datatypes.SampleParam;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.datatypes.VerdictResultSet;
 import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.Relation;
+import edu.umich.verdict.relation.SingleRelation;
 import edu.umich.verdict.util.VerdictLogger;
 
 public class DbmsHive extends DbmsImpala {
@@ -34,15 +36,17 @@ public class DbmsHive extends DbmsImpala {
 		return executeQuery("show databases");
 	}
 	
-	protected TableUniqueName justCreateUniverseSampleTableOf(SampleParam param) throws VerdictException {
+	protected void justCreateUniverseSampleTableOf(SampleParam param) throws VerdictException {
 		TableUniqueName sampleTableName = param.sampleTableName();
-		String sql = String.format("CREATE TABLE %s AS SELECT * FROM %s "
-								 + "WHERE pmod(conv(substr(md5(%s),17,16),16,10),10000) <= %.4f",
-								 sampleTableName, param.originalTable, param.columnNames.get(0), param.samplingRatio*10000);
-		VerdictLogger.debug(this, String.format("Creates a table: %s", sql));
+		String sql = String.format("CREATE TABLE %s AS ", sampleTableName) + 
+					 SingleRelation.from(vc, param.originalTable)
+					 .where(String.format("pmod(conv(substr(md5(%s),17,16),16,10),10000) <= %.4f", param.columnNames.get(0), param.samplingRatio*10000))
+					 .select("*, round(rand(unix_timestamp())*100)%100 AS " + partitionColumnName()).toSql();
+		
+		VerdictLogger.debug(this, String.format("Creates a table: %s using the following statement:", sampleTableName));
+		VerdictLogger.debugPretty(this, Relation.prettyfySql(sql), "  ");
 		this.executeUpdate(sql);
 		VerdictLogger.debug(this, "Done.");
-		return sampleTableName;
 	}
 	
 }

--- a/core/src/main/java/edu/umich/verdict/dbms/DbmsHive.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/DbmsHive.java
@@ -2,16 +2,30 @@ package edu.umich.verdict.dbms;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.base.Joiner;
 
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.SampleParam;
+import edu.umich.verdict.datatypes.SampleSizeInfo;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.datatypes.VerdictResultSet;
 import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.ExactRelation;
 import edu.umich.verdict.relation.Relation;
 import edu.umich.verdict.relation.SingleRelation;
+import edu.umich.verdict.relation.condition.CompCond;
+import edu.umich.verdict.relation.expr.BinaryOpExpr;
+import edu.umich.verdict.relation.expr.ConstantExpr;
+import edu.umich.verdict.relation.expr.Expr;
+import edu.umich.verdict.relation.expr.SubqueryExpr;
 import edu.umich.verdict.util.VerdictLogger;
 
 public class DbmsHive extends DbmsImpala {
@@ -36,17 +50,105 @@ public class DbmsHive extends DbmsImpala {
 		return executeQuery("show databases");
 	}
 	
+	@Override
+	protected void justCreateStratifiedSampleTableof(SampleParam param) throws VerdictException {
+		SampleSizeInfo info = vc.getMeta().getSampleSizeOf(new SampleParam(param.originalTable, "uniform", null, new ArrayList<String>()));
+		if (info == null) {
+			String msg = "A uniform random must first be created before creating a stratified sample.";
+			VerdictLogger.error(this, msg);
+			throw new VerdictException(msg);
+		}
+		
+		long originalTableSize = info.originalTableSize;
+		double samplingProbability = param.samplingRatio;
+		String groupName = Joiner.on(", ").join(param.columnNames);
+		String samplingProbColInQuote = quote(vc.getDbms().samplingProbabilityColumnName());
+		TableUniqueName sampleTable = param.sampleTableName();
+		String allColumns = Joiner.on(", ").join(vc.getMeta().getColumnNames(param.originalTable));
+		
+		long groupCount = SingleRelation.from(vc, param.originalTable)
+									.countDistinctValue(groupName);
+		Expr threshold = BinaryOpExpr.from(
+				ConstantExpr.from(originalTableSize),
+				BinaryOpExpr.from(
+						BinaryOpExpr.from(
+								ConstantExpr.from(samplingProbability),
+								ConstantExpr.from("grp_size"), "/"),
+						ConstantExpr.from(groupCount),
+						"/"),
+				"*");
+		ExactRelation sampleWithGrpSize
+		  = SingleRelation.from(vc, param.originalTable)
+			.select(Arrays.asList("*", String.format("count(*) over (partition by %s) AS grp_size", groupName)))
+			.where(CompCond.from(Expr.from("rand(unix_timestamp())"), "<", threshold));
+		ExactRelation sampleWithSamplingProb
+		  = sampleWithGrpSize.select(
+				  allColumns + ", "
+		          + String.format("count(*) over (partition by %s) / grp_size AS %s", groupName, samplingProbColInQuote) + ", "
+		  		  + randomPartitionColumn());
+		
+		String sql = String.format("CREATE TABLE %s AS ", sampleTable)
+					 + sampleWithSamplingProb.toSql();
+		VerdictLogger.debug(this, "The query used for creating a stratified sample:");
+		VerdictLogger.debugPretty(this, Relation.prettyfySql(sql), "  ");
+		executeUpdate(sql);
+	}
+		
+	@Override
 	protected void justCreateUniverseSampleTableOf(SampleParam param) throws VerdictException {
 		TableUniqueName sampleTableName = param.sampleTableName();
-		String sql = String.format("CREATE TABLE %s AS ", sampleTableName) + 
-					 SingleRelation.from(vc, param.originalTable)
-					 .where(String.format("pmod(conv(substr(md5(%s),17,16),16,10),10000) <= %.4f", param.columnNames.get(0), param.samplingRatio*10000))
-					 .select("*, round(rand(unix_timestamp())*100)%100 AS " + partitionColumnName()).toSql();
+		List<String> colNames = vc.getMeta().getColumnNames(param.originalTable);
+		String samplingProbColInQuote = quote(vc.getDbms().samplingProbabilityColumnName());
+				
+		ExactRelation withSize = SingleRelation.from(vc, param.originalTable)
+								 .select("*, count(*) over () AS " + quote("__total_size"));
+		ExactRelation sampled = withSize.where(
+									modOfHash(param.columnNames.get(0), 1000000) + 
+									String.format(" < %.2f", param.samplingRatio*1000000))
+					 			.select(Joiner.on(", ").join(colNames)
+					 					+ ", count(*) over () / " + quote("__total_size") + " AS " + samplingProbColInQuote + ", "
+					 					+ randomPartitionColumn());
+		
+		String sql = String.format("CREATE TABLE %s AS ", sampleTableName)
+				     + sampled.toSql();
 		
 		VerdictLogger.debug(this, String.format("Creates a table: %s using the following statement:", sampleTableName));
 		VerdictLogger.debugPretty(this, Relation.prettyfySql(sql), "  ");
 		this.executeUpdate(sql);
 		VerdictLogger.debug(this, "Done.");
+	}
+	
+	@Override
+	public String modOfHash(String col, int mod) {
+		return String.format("pmod(conv(substr(md5(cast(%s AS string)),17,16),16,10), %d)", col, mod);
+	}
+
+	@Override
+	public Pair<Long, Long> createUniformRandomSampleTableOf(SampleParam param) throws VerdictException {
+		dropTable(param.sampleTableName());
+		
+		String samplingProbColInQuote = quote(vc.getDbms().samplingProbabilityColumnName());
+		List<String> colNames = vc.getMeta().getColumnNames(param.originalTable);
+		
+		ExactRelation sampled = SingleRelation.from(vc, param.originalTable)
+                .select("*, count(*) OVER () AS " + quote("__total_size"))
+		        .where(CompCond.from(Expr.from("rand(unix_timestamp())"), "<", ConstantExpr.from(param.samplingRatio)));
+		sampled = sampled.select(
+				Joiner.on(", ").join(colNames) +
+				", count(*) over () / " + quote("__total_size") + " AS " + samplingProbColInQuote + ", " +  // attach sampling prob
+				randomPartitionColumn());										 // attach partition number
+		
+		String sql = String.format("create table %s AS ", param.sampleTableName()) + sampled.toSql();
+		VerdictLogger.debug(this, "The query used for creating a uniform random sample:");
+		VerdictLogger.debugPretty(this, Relation.prettyfySql(sql), "  ");
+		
+		executeUpdate(sql);
+		
+		return Pair.of(getTableSize(param.sampleTableName()), getTableSize(param.originalTable));
+	}
+	
+	protected String quote(String expr) {
+		return String.format("`%s`", expr);
 	}
 	
 }

--- a/core/src/main/java/edu/umich/verdict/dbms/DbmsImpala.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/DbmsImpala.java
@@ -118,6 +118,11 @@ public class DbmsImpala extends Dbms {
 //		dropTable(tempTableName);
 	}
 	
+	@Override
+	public ExactRelation augmentWithRandomPartitionNum(ExactRelation r) {
+		return r.select("*, " + randomPartitionColumn());
+	}
+
 	/**
 	 * Creates a universe sample table without dropping an old table.
 	 * @param originalTableName
@@ -139,7 +144,8 @@ public class DbmsImpala extends Dbms {
 	}
 	
 	private String randomPartitionColumn() {
-		return "round(rand(unix_timestamp())*100)%100 AS " + partitionColumnName();
+		int pcount = partitionCount();
+		return String.format("round(rand(unix_timestamp())*%d) %% %d AS %s", pcount, pcount, partitionColumnName());
 	}
 	
 	private String columnNamesInString(TableUniqueName tableName) {

--- a/core/src/main/java/edu/umich/verdict/query/SelectStatementBaseRewriter.java
+++ b/core/src/main/java/edu/umich/verdict/query/SelectStatementBaseRewriter.java
@@ -296,10 +296,10 @@ public class SelectStatementBaseRewriter extends VerdictSQLBaseVisitor<String> {
 //		return visit(ctx.aggregate_windowed_function());
 //	}
 	
-	@Override public String visitMathematical_function_expression(VerdictSQLParser.Mathematical_function_expressionContext ctx)
-	{
-		return String.format("%s(%s)", ctx.unary_mathematical_function().getText(), visit(ctx.expression()));
-	}
+//	@Override public String visitMathematical_function_expression(VerdictSQLParser.Mathematical_function_expressionContext ctx)
+//	{
+//		return String.format("%s(%s)", ctx.unary_mathematical_function().getText(), visit(ctx.expression()));
+//	}
 	
 	@Override
 	public String visitAggregate_windowed_function(VerdictSQLParser.Aggregate_windowed_functionContext ctx) {

--- a/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
@@ -59,6 +59,22 @@ public class AggregatedRelation extends ExactRelation {
 			candidates_list.add(candidates);
 		}
 		
+		// check if any of them include sample tables. If no sample table is included, we do not approximate.
+		boolean includeSample = false;
+		for (List<SampleGroup> candidates : candidates_list) {
+			for (SampleGroup g : candidates) {
+				if (g.samplingProb() < 1.0) {
+					includeSample = true;
+					break;
+				}
+			}
+			if (includeSample) break;
+		}
+		
+		if (!includeSample) {
+			return new NoApproxRelation(this);
+		}
+		
 		// We test if we can consolidate those sample candidates so that the number of select statements is less than
 		// the number of the expressions. In the worst case (e.g., all count-distinct), the number of select statements
 		// will be equal to the number of the expressions. If the cost of running those select statements individually
@@ -167,6 +183,11 @@ public class AggregatedRelation extends ExactRelation {
 		
 		elems.addAll(this.elems);		// agg list
 		
+		return elems;
+	}
+
+	@Override
+	public List<SelectElem> selectElemsWithAggregateSource() {
 		return elems;
 	}
 

--- a/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
@@ -43,6 +43,10 @@ public class AggregatedRelation extends ExactRelation {
 		return source;
 	}
 	
+	public List<SelectElem> getAggList() {
+		return elems;
+	}
+	
 	/*
 	 * Approx
 	 */
@@ -119,6 +123,7 @@ public class AggregatedRelation extends ExactRelation {
 		return sql.toString();
 	}
 	
+	@Deprecated
 	protected String withoutSelectSql() {
 		StringBuilder sql = new StringBuilder();
 		
@@ -148,6 +153,21 @@ public class AggregatedRelation extends ExactRelation {
 		if (csql.length() > 0) { sql.append(" WHERE "); sql.append(csql); }
 		if (groupby.size() > 0) { sql.append(" GROUP BY "); sql.append(Joiner.on(", ").join(groupby)); }
 		return sql.toString();
+	}
+
+	@Override
+	public List<SelectElem> getSelectList() {
+		List<SelectElem> elems = new ArrayList<SelectElem>();
+		
+		Pair<List<Expr>, ExactRelation> groupsAndNextR = allPrecedingGroupbys(this.source);
+		List<Expr> groupby = groupsAndNextR.getLeft();
+		for (Expr g : groupby) {
+			elems.add(new SelectElem(g));
+		}
+		
+		elems.addAll(this.elems);		// agg list
+		
+		return elems;
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
@@ -1,6 +1,7 @@
 package edu.umich.verdict.relation;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -196,6 +197,11 @@ public class AggregatedRelation extends ExactRelation {
 		ColNameExpr col = source.partitionColumn();
 		col.setTab(getAliasName());
 		return col;
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		return Arrays.asList();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
@@ -19,14 +19,18 @@ import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.condition.Cond;
 import edu.umich.verdict.relation.expr.ColNameExpr;
+import edu.umich.verdict.relation.expr.ConstantExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.SelectElem;
+import edu.umich.verdict.util.VerdictLogger;
 
 public class AggregatedRelation extends ExactRelation {
 
 	protected ExactRelation source;
 	
 	protected List<SelectElem> elems;
+	
+	private boolean includeGroupsInToSql = true;
 	
 	protected AggregatedRelation(VerdictContext vc, ExactRelation source, List<SelectElem> elems) {
 		super(vc);
@@ -46,6 +50,10 @@ public class AggregatedRelation extends ExactRelation {
 	
 	public List<SelectElem> getAggList() {
 		return elems;
+	}
+	
+	public void setIncludeGroupsInToSql(boolean o) {
+		includeGroupsInToSql = o;
 	}
 	
 	/*
@@ -79,10 +87,13 @@ public class AggregatedRelation extends ExactRelation {
 		// We test if we can consolidate those sample candidates so that the number of select statements is less than
 		// the number of the expressions. In the worst case (e.g., all count-distinct), the number of select statements
 		// will be equal to the number of the expressions. If the cost of running those select statements individually
-		// is higher than the cost of running a single select statement using the original tables, we do not use samples.
+		// is higher than the cost of running a single select statement using the original tables, samples are not used.
 		SamplePlan plan = consolidate(candidates_list);
-		List<ApproxAggregatedRelation> individuals = new ArrayList<ApproxAggregatedRelation>();
+		VerdictLogger.debug(this, "The sample plan to use: ");
+		VerdictLogger.debugPretty(this, plan.toPrettyString(), "  ");
 		
+		// we create multiple aggregated relations, which, when combined, can answer the user-submitted query.
+		List<ApproxAggregatedRelation> individuals = new ArrayList<ApproxAggregatedRelation>();
 		for (SampleGroup group : plan.getSampleGroups()) {
 			List<SelectElem> elems = group.getElems();
 			Set<SampleParam> samplesPart = group.sampleSet();
@@ -105,12 +116,29 @@ public class AggregatedRelation extends ExactRelation {
 					for (ColNameExpr col : groupby) {
 						joincols.add(Pair.of((Expr) new ColNameExpr(col.getCol(), ln), (Expr) new ColNameExpr(col.getCol(), rn)));
 					}
+//					r1.setIncludeGroupsInToSql(false);
 					r = new ApproxJoinedRelation(vc, r, r1, joincols);
 				} else {
 					r = new ApproxJoinedRelation(vc, r, r1, null);
 				}
 			}
 		}
+		
+		// if two or more tables are joined, groupby columns become ambiguous. So, we project out the groupby columns
+		// in the joined relations.
+		ApproxRelation firstSource = individuals.get(0).getSource();
+		if (individuals.size() > 1 && (firstSource instanceof ApproxGroupedRelation)) {
+			List<ColNameExpr> groupby = ((ApproxGroupedRelation) firstSource).getGroupby();
+			List<SelectElem> newElems = new ArrayList<SelectElem>();
+			for (ColNameExpr g : groupby) {
+				newElems.add(new SelectElem(new ColNameExpr(g.getCol(), individuals.get(0).getAliasName())));
+			}
+			for (SelectElem elem : elems) {
+				newElems.add(new SelectElem(ConstantExpr.from(elem.getAlias()), elem.getAlias()));
+			}
+			r = new ApproxProjectedRelation(vc, r, newElems);
+		}
+		
 		r.setAliasName(getAliasName());
 		return r;
 	}
@@ -134,8 +162,12 @@ public class AggregatedRelation extends ExactRelation {
 	protected String selectSql(List<Expr> groupby) {
 		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT ");
-		sql.append(Joiner.on(", ").join(groupby));
-		if (groupby.size() > 0) sql.append(", ");
+		
+		if (includeGroupsInToSql) {
+			sql.append(Joiner.on(", ").join(groupby));
+			if (groupby.size() > 0) sql.append(", ");
+		}
+		
 		sql.append(Joiner.on(", ").join(elems));
 		return sql.toString();
 	}
@@ -204,4 +236,13 @@ public class AggregatedRelation extends ExactRelation {
 		return Arrays.asList();
 	}
 
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAliasName(), Joiner.on(", ").join(elems)));
+		s.append(source.toStringWithIndent(indent + "  "));
+		return s.toString();
+	}
+	
 }

--- a/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/AggregatedRelation.java
@@ -191,4 +191,11 @@ public class AggregatedRelation extends ExactRelation {
 		return elems;
 	}
 
+	@Override
+	public ColNameExpr partitionColumn() {
+		ColNameExpr col = source.partitionColumn();
+		col.setTab(getAliasName());
+		return col;
+	}
+
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxAggregatedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxAggregatedRelation.java
@@ -167,7 +167,7 @@ public class ApproxAggregatedRelation extends ApproxRelation {
 	
 	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
-		return source.samplingProbabilityFor(f);
+		return 1.0;
 	}
 	
 	private Expr transformForSingleFunctionWithPartitionSize(
@@ -270,7 +270,7 @@ public class ApproxAggregatedRelation extends ApproxRelation {
 					double samplingProb = source.samplingProbabilityFor(f);
 					
 					if (f.getFuncName().equals(FuncExpr.FuncName.COUNT)) {
-						Expr est = FuncExpr.sum(scaleForSampling(samplingProb, samplingProbCols));
+						Expr est = FuncExpr.sum(scaleForSampling(samplingProbCols));
 						return FuncExpr.round(est);
 					}
 					else if (f.getFuncName().equals(FuncExpr.FuncName.COUNT_DISTINCT)) {

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxFilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxFilteredRelation.java
@@ -34,6 +34,7 @@ public class ApproxFilteredRelation extends ApproxRelation {
 		super(vc);
 		this.source = source;
 		this.cond = cond;
+		this.alias = source.alias;
 	}
 
 	public ApproxRelation getSource() {
@@ -101,7 +102,7 @@ public class ApproxFilteredRelation extends ApproxRelation {
 		ExactRelation joinedSource = source.rewriteWithPartition();
 		for (ApproxRelation a : relToJoin) {
 			List<Pair<Expr, Expr>> joinCol = Arrays.asList(Pair.<Expr, Expr>of(
-					source.partitionColumn(),
+					joinedSource.partitionColumn(),
 					new ColNameExpr(partitionColumnName(), a.sourceTableName())));
 			joinedSource = JoinedRelation.from(vc, joinedSource, a.rewriteWithPartition(), joinCol);
 		}
@@ -124,11 +125,6 @@ public class ApproxFilteredRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected ColNameExpr partitionColumn() {
-		return source.partitionColumn();
-	}
-	
-	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
 		return source.samplingProbabilityFor(f);
 	}
@@ -143,11 +139,6 @@ public class ApproxFilteredRelation extends ApproxRelation {
 		return source.sampleType();
 	}
 	
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		return source.accumulateStratifiedSamples();
-	}
-
 	@Override
 	protected List<String> sampleColumns() {
 		return source.sampleColumns();

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxFilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxFilteredRelation.java
@@ -1,20 +1,28 @@
 package edu.umich.verdict.relation;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.collect.ImmutableMap;
 
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.condition.AndCond;
 import edu.umich.verdict.relation.condition.CompCond;
 import edu.umich.verdict.relation.condition.Cond;
 import edu.umich.verdict.relation.condition.CondModifier;
+import edu.umich.verdict.relation.condition.OrCond;
 import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.ExprModifier;
 import edu.umich.verdict.relation.expr.FuncExpr;
+import edu.umich.verdict.relation.expr.SubqueryExpr;
+import edu.umich.verdict.util.VerdictLogger;
 
 public class ApproxFilteredRelation extends ApproxRelation {
 	
@@ -37,10 +45,87 @@ public class ApproxFilteredRelation extends ApproxRelation {
 	}
 
 	@Override
-	public ExactRelation rewrite() {
-		ExactRelation r = new FilteredRelation(vc, source.rewrite(), condWithApprox(cond, tableSubstitution()));
+	public ExactRelation rewriteForPointEstimate() {
+		ExactRelation r = new FilteredRelation(vc, source.rewriteForPointEstimate(), condWithApprox(cond, tableSubstitution()));
 		r.setAliasName(getAliasName());
 		return r;
+	}
+	
+	/**
+	 * Returns a new condition in which old column names are replaced with the column names of sample tables. 
+	 * @param cond
+	 * @param sub Map of original table name and its substitution.
+	 * @return
+	 */
+	private Cond condWithApprox(Cond cond, final Map<String, String> sub) {
+		CondModifier v = new CondModifier() {
+			ExprModifier v2 = new ExprModifier() {
+				public Expr call(Expr expr) {
+					if (expr instanceof ColNameExpr) {
+						ColNameExpr e = (ColNameExpr) expr;
+						return new ColNameExpr(e.getCol(), sub.get(e.getTab()), e.getSchema());
+					} else if (expr instanceof SubqueryExpr) {
+						Relation r = ((SubqueryExpr) expr).getSubquery();
+						if (r instanceof ApproxRelation) {
+							return SubqueryExpr.from(((ApproxRelation) r).rewrite());
+						} else {
+							VerdictLogger.warn(this, "An exact relation is found in an approximate query statement."
+									+ " Mixing approximate relations with exact relations are not supported.");
+							return expr;
+						}
+					} else {
+						return expr;
+					}
+				}
+			};
+			
+			public Cond call(Cond cond) {
+				if (cond instanceof CompCond) {
+					CompCond c = (CompCond) cond;
+					return CompCond.from(v2.visit(c.getLeft()), c.getOp(), v2.visit(c.getRight()));
+				} else {
+					return cond;
+				}
+			}			
+		};
+		return v.visit(cond);
+	}
+	
+	@Override
+	public ExactRelation rewriteWithPartition() {
+		// check if there's any comparison operations with subqueries.
+		Pair<Cond, List<ApproxRelation>> modifiedCondWithRelToJoin = transformCondWithPartitionedRelations(cond, tableSubstitution());
+		Cond modifiedCond = modifiedCondWithRelToJoin.getLeft();
+		List<ApproxRelation> relToJoin = modifiedCondWithRelToJoin.getRight();
+		
+		ExactRelation joinedSource = source.rewriteWithPartition();
+		for (ApproxRelation a : relToJoin) {
+			List<Pair<Expr, Expr>> joinCol = Arrays.asList(Pair.<Expr, Expr>of(
+					source.partitionColumn(),
+					new ColNameExpr(partitionColumnName(), a.sourceTableName())));
+			joinedSource = JoinedRelation.from(vc, joinedSource, a.rewriteWithPartition(), joinCol);
+		}
+		
+		ExactRelation r = new FilteredRelation(vc, joinedSource, modifiedCond);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	/**
+	 * 
+	 * @param cond
+	 * @return A pair of (1) the transformed condition and (2) a list of tables to be inner-joined on partition numbers.
+	 * 		   The relations to be joined must have two selectElems: partition number and an aggregate column in order.
+	 */
+	private Pair<Cond, List<ApproxRelation>> transformCondWithPartitionedRelations(Cond cond, Map<String, String> sub) {
+		CondModifierForSubsampling v = new CondModifierForSubsampling(sub);
+		Cond modified = v.visit(cond);
+		return Pair.of(modified, v.relationsToJoin());
+	}
+	
+	@Override
+	protected ColNameExpr partitionColumn() {
+		return source.partitionColumn();
 	}
 	
 	@Override
@@ -68,4 +153,53 @@ public class ApproxFilteredRelation extends ApproxRelation {
 		return source.sampleColumns();
 	}
 
+}
+
+class CondModifierForSubsampling extends CondModifier {
+	private List<ApproxRelation> compToRelations = new ArrayList<ApproxRelation>();
+	
+	private Map<String, String> sub;
+	
+	public CondModifierForSubsampling(Map<String, String> tableSub) {
+		sub = tableSub;
+	}
+	
+	public List<ApproxRelation> relationsToJoin() {
+		return compToRelations;
+	}
+	
+	ExprModifier v2 = new ExprModifier() {
+		public Expr call(Expr expr) {
+			if (expr instanceof ColNameExpr) {
+				ColNameExpr e = (ColNameExpr) expr;
+				return new ColNameExpr(e.getCol(), sub.get(e.getTab()), e.getSchema());
+			} else if (expr instanceof SubqueryExpr) {
+				Relation r = ((SubqueryExpr) expr).getSubquery();
+				if (r instanceof ApproxAggregatedRelation) {
+					// replace the subquery with the first aggregate expression.
+					compToRelations.add((ApproxRelation) r);
+					return new ColNameExpr(((ApproxAggregatedRelation) r).getSelectList().get(0).getAlias());
+				} else if (r instanceof ApproxProjectedRelation) {
+					// replace the subquery with the first select elem expression.
+					compToRelations.add((ApproxRelation) r);
+					return new ColNameExpr(((ApproxProjectedRelation) r).getSelectElems().get(0).getAlias());
+				} else {
+					VerdictLogger.warn(this, "An exact relation is found in an approximate query statement."
+							+ " Mixing approximate relations with exact relations are not supported.");
+					return expr;
+				}
+			} else {
+				return expr;
+			}
+		}
+	};
+	
+	public Cond call(Cond cond) {
+		if (cond instanceof CompCond) {
+			CompCond c = (CompCond) cond;
+			return CompCond.from(v2.visit(c.getLeft()), c.getOp(), v2.visit(c.getRight()));
+		} else {
+			return cond;
+		}
+	}			
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxFilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxFilteredRelation.java
@@ -125,8 +125,8 @@ public class ApproxFilteredRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected double samplingProbabilityFor(FuncExpr f) {
-		return source.samplingProbabilityFor(f);
+	protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+		return source.samplingProbabilityExprsFor(f);
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxGroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxGroupedRelation.java
@@ -42,17 +42,19 @@ public class ApproxGroupedRelation extends ApproxRelation {
 	
 	@Override
 	public ExactRelation rewriteWithPartition() {
+		ExactRelation newSource = source.rewriteWithPartition();
 		List<ColNameExpr> newGroupby = groupbyWithTablesSubstituted();
-		newGroupby.add((ColNameExpr) exprWithTableNamesSubstituted(partitionColumn(), tableSubstitution()));
-		ExactRelation r = new GroupedRelation(vc, source.rewriteWithPartition(), newGroupby);
+//		newGroupby.add((ColNameExpr) exprWithTableNamesSubstituted(partitionColumn(), tableSubstitution()));
+		newGroupby.add(newSource.partitionColumn());
+		ExactRelation r = new GroupedRelation(vc, newSource, newGroupby);
 		r.setAliasName(r.getAliasName());
 		return r;
 	}
 	
-	@Override
-	protected ColNameExpr partitionColumn() {
-		return source.partitionColumn();
-	}
+//	@Override
+//	protected ColNameExpr partitionColumn() {
+//		return source.partitionColumn();
+//	}
 
 	@Override
 	// TODO: make this more accurate for handling IN and EXISTS predicates.

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxGroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxGroupedRelation.java
@@ -22,6 +22,7 @@ public class ApproxGroupedRelation extends ApproxRelation {
 		super(vc);
 		this.source = source;
 		this.groupby = groupby;
+		this.alias = source.alias;
 	}
 	
 	public ApproxRelation getSource() {
@@ -79,11 +80,6 @@ public class ApproxGroupedRelation extends ApproxRelation {
 	@Override
 	protected String sampleType() {
 		return source.sampleType();
-	}
-	
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		return source.accumulateStratifiedSamples();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxGroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxGroupedRelation.java
@@ -59,8 +59,8 @@ public class ApproxGroupedRelation extends ApproxRelation {
 
 	@Override
 	// TODO: make this more accurate for handling IN and EXISTS predicates.
-	protected double samplingProbabilityFor(FuncExpr f) {
-		return source.samplingProbabilityFor(f);
+	protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+		return source.samplingProbabilityExprsFor(f);
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxJoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxJoinedRelation.java
@@ -50,6 +50,7 @@ public class ApproxJoinedRelation extends ApproxRelation {
 		} else {
 			this.joinCols = joinCols;
 		}
+		this.alias = null;
 	}
 	
 	public static ApproxJoinedRelation from(VerdictContext vc, ApproxRelation source1, ApproxRelation source2, List<Pair<Expr, Expr>> joinCols) {
@@ -102,11 +103,6 @@ public class ApproxJoinedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected ColNameExpr partitionColumn() {
-		return source1.partitionColumn();
-	}
-	
-	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
 		if (areMatchingUniverseSamples()) {
 			return Math.min(source1.samplingProbabilityFor(f), source2.samplingProbabilityFor(f));
@@ -151,13 +147,6 @@ public class ApproxJoinedRelation extends ApproxRelation {
 		} else {
 			return null;
 		}
-	}
-	
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		List<TableUniqueName> union = new ArrayList<TableUniqueName>(source1.accumulateStratifiedSamples());
-		union.addAll(source2.accumulateStratifiedSamples());
-		return union;
 	}
 	
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxJoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxJoinedRelation.java
@@ -25,6 +25,7 @@ import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.ExprModifier;
 import edu.umich.verdict.relation.expr.FuncExpr;
+import edu.umich.verdict.util.VerdictLogger;
 
 public class ApproxJoinedRelation extends ApproxRelation {
 
@@ -89,9 +90,17 @@ public class ApproxJoinedRelation extends ApproxRelation {
 	@Override
 	public ExactRelation rewriteForPointEstimate() {
 		List<Pair<Expr, Expr>> newJoinCond = joinCondWithTablesSubstitutioned();
-		ExactRelation r = JoinedRelation.from(vc, source1.rewriteForPointEstimate(), source2.rewriteForPointEstimate(), newJoinCond);
+		ExactRelation r = new JoinedRelation(vc, source1.rewriteForPointEstimate(), source2.rewriteForPointEstimate(), newJoinCond);
 		r.setAliasName(getAliasName());
 		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithSubsampledErrorBounds() {
+		ExactRelation r1 = source1.rewriteWithSubsampledErrorBounds();
+		ExactRelation r2 = source2.rewriteWithSubsampledErrorBounds();
+		List<Pair<Expr, Expr>> newJoinCond = joinCondWithTablesSubstitutioned();
+		return new JoinedRelation(vc, r1, r2, newJoinCond);
 	}
 	
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxLimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxLimitedRelation.java
@@ -8,7 +8,9 @@ import com.google.common.collect.ImmutableMap;
 
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.FuncExpr;
+import edu.umich.verdict.util.VerdictLogger;
 
 public class ApproxLimitedRelation extends ApproxRelation {
 	
@@ -23,10 +25,29 @@ public class ApproxLimitedRelation extends ApproxRelation {
 	}
 
 	@Override
-	public ExactRelation rewrite() {
-		ExactRelation r = new LimitedRelation(vc, source.rewrite(), limit);
+	public ExactRelation rewriteForPointEstimate() {
+		ExactRelation r = new LimitedRelation(vc, source.rewriteForPointEstimate(), limit);
 		r.setAliasName(getAliasName());
 		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithSubsampledErrorBounds() {
+		ExactRelation r = new LimitedRelation(vc, source.rewriteWithSubsampledErrorBounds(), limit);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithPartition() {
+		ExactRelation r = new LimitedRelation(vc, source.rewriteWithPartition(), limit);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	@Override
+	protected ColNameExpr partitionColumn() {
+		return source.partitionColumn();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxLimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxLimitedRelation.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.relation.expr.ColNameExpr;
+import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.FuncExpr;
 import edu.umich.verdict.util.VerdictLogger;
 
@@ -47,8 +48,8 @@ public class ApproxLimitedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected double samplingProbabilityFor(FuncExpr f) {
-		return source.samplingProbabilityFor(f);
+	protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+		return source.samplingProbabilityExprsFor(f);
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxLimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxLimitedRelation.java
@@ -22,6 +22,7 @@ public class ApproxLimitedRelation extends ApproxRelation {
 		super(vc);
 		this.source = source;
 		this.limit = limit;
+		this.alias = source.alias;
 	}
 
 	@Override
@@ -46,11 +47,6 @@ public class ApproxLimitedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected ColNameExpr partitionColumn() {
-		return source.partitionColumn();
-	}
-
-	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
 		return source.samplingProbabilityFor(f);
 	}
@@ -63,11 +59,6 @@ public class ApproxLimitedRelation extends ApproxRelation {
 	@Override
 	protected String sampleType() {
 		return null;
-	}
-	
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		return source.accumulateStratifiedSamples();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxOrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxOrderedRelation.java
@@ -24,6 +24,7 @@ public class ApproxOrderedRelation extends ApproxRelation {
 		super(vc);
 		this.source = source;
 		this.orderby = orderby;
+		this.alias = source.alias;
 	}
 
 	@Override
@@ -48,11 +49,6 @@ public class ApproxOrderedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected ColNameExpr partitionColumn() {
-		return source.partitionColumn();
-	}
-
-	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
 		return source.samplingProbabilityFor(f);
 	}
@@ -65,11 +61,6 @@ public class ApproxOrderedRelation extends ApproxRelation {
 	@Override
 	protected String sampleType() {
 		return source.sampleType();
-	}
-	
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		return source.accumulateStratifiedSamples();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxOrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxOrderedRelation.java
@@ -49,8 +49,8 @@ public class ApproxOrderedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected double samplingProbabilityFor(FuncExpr f) {
-		return source.samplingProbabilityFor(f);
+	protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+		return source.samplingProbabilityExprsFor(f);
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxOrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxOrderedRelation.java
@@ -12,6 +12,7 @@ import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.FuncExpr;
 import edu.umich.verdict.relation.expr.OrderByExpr;
+import edu.umich.verdict.util.VerdictLogger;
 
 public class ApproxOrderedRelation extends ApproxRelation {
 	
@@ -26,10 +27,29 @@ public class ApproxOrderedRelation extends ApproxRelation {
 	}
 
 	@Override
-	public ExactRelation rewrite() {
-		ExactRelation r = new OrderedRelation(vc, source.rewrite(), orderby);
+	public ExactRelation rewriteForPointEstimate() {
+		ExactRelation r = new OrderedRelation(vc, source.rewriteForPointEstimate(), orderby);
 		r.setAliasName(getAliasName());
 		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithSubsampledErrorBounds() {
+		ExactRelation r = new OrderedRelation(vc, source.rewriteWithSubsampledErrorBounds(), orderby);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithPartition() {
+		ExactRelation r = new OrderedRelation(vc, source.rewriteWithPartition(), orderby);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	@Override
+	protected ColNameExpr partitionColumn() {
+		return source.partitionColumn();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
@@ -53,7 +53,7 @@ public class ApproxProjectedRelation extends ApproxRelation {
 			}
 		}
 		
-		// we look for error bound columns based on the assumption that the error bound columns have the suffix attached
+		// we search for error bound columns based on the assumption that the error bound columns have the suffix attached
 		// to the original agg columns. The suffix is obtained from the ApproxRelation#errColSuffix() method.
 		// ApproxAggregatedRelation#rewriteWithSubsampledErrorBounds() method is responsible for having those columns. 
 		List<SelectElem> elemsWithErr = new ArrayList<SelectElem>();

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
@@ -78,11 +78,6 @@ public class ApproxProjectedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected ColNameExpr partitionColumn() {
-		return source.partitionColumn();
-	}
-
-	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
 		return source.samplingProbabilityFor(f);
 	}
@@ -95,11 +90,6 @@ public class ApproxProjectedRelation extends ApproxRelation {
 	@Override
 	protected String sampleType() {
 		return source.sampleType();
-	}
-	
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		return source.accumulateStratifiedSamples();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
@@ -59,7 +59,7 @@ public class ApproxProjectedRelation extends ApproxRelation {
 		List<SelectElem> elemsWithErr = new ArrayList<SelectElem>();
 		for (SelectElem e : elems) {
 			elemsWithErr.add(e);
-			String errColName = e.getExpr().toString() + errColSuffix();
+			String errColName = e.getExpr().getText() + errColSuffix();
 			if (colAliases.contains(errColName)) {
 				elemsWithErr.add(new SelectElem(new ColNameExpr(errColName), errColName));
 			}

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
@@ -7,8 +7,10 @@ import com.google.common.collect.ImmutableMap;
 
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.FuncExpr;
 import edu.umich.verdict.relation.expr.SelectElem;
+import edu.umich.verdict.util.VerdictLogger;
 
 public class ApproxProjectedRelation extends ApproxRelation {
 	
@@ -21,12 +23,35 @@ public class ApproxProjectedRelation extends ApproxRelation {
 		this.source = source;
 		this.elems = elems;
 	}
+	
+	public List<SelectElem> getSelectElems() {
+		return elems;
+	}
 
 	@Override
-	public ExactRelation rewrite() {
-		ExactRelation r = new ProjectedRelation(vc, source.rewrite(), elems);
+	public ExactRelation rewriteForPointEstimate() {
+		ExactRelation r = new ProjectedRelation(vc, source.rewriteForPointEstimate(), elems);
 		r.setAliasName(getAliasName());
 		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithSubsampledErrorBounds() {
+		ExactRelation r = new ProjectedRelation(vc, source.rewriteWithSubsampledErrorBounds(), elems);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithPartition() {
+		ExactRelation r = new ProjectedRelation(vc, source.rewriteWithPartition(), elems);
+		r.setAliasName(getAliasName());
+		return r;
+	}
+	
+	@Override
+	protected ColNameExpr partitionColumn() {
+		return source.partitionColumn();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
@@ -78,13 +78,22 @@ public class ApproxProjectedRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected double samplingProbabilityFor(FuncExpr f) {
-		return source.samplingProbabilityFor(f);
+	protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+		List<Expr> exprs = source.samplingProbabilityExprsFor(f);
+		List<Expr> exprsWithNewAlias = new ArrayList<Expr>();
+		for (Expr e : exprs) {
+			if (e instanceof ColNameExpr) {
+				exprsWithNewAlias.add(new ColNameExpr(((ColNameExpr) e).getCol(), alias));
+			} else {
+				exprsWithNewAlias.add(e);
+			}
+		}
+		return exprsWithNewAlias;
 	}
 
 	@Override
 	protected Map<String, String> tableSubstitution() {
-		return ImmutableMap.of();
+		return source.tableSubstitution();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxProjectedRelation.java
@@ -1,13 +1,18 @@
 package edu.umich.verdict.relation;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
 
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.relation.expr.ColNameExpr;
+import edu.umich.verdict.relation.expr.Expr;
+import edu.umich.verdict.relation.expr.ExprVisitor;
 import edu.umich.verdict.relation.expr.FuncExpr;
 import edu.umich.verdict.relation.expr.SelectElem;
 import edu.umich.verdict.util.VerdictLogger;
@@ -37,7 +42,30 @@ public class ApproxProjectedRelation extends ApproxRelation {
 	
 	@Override
 	public ExactRelation rewriteWithSubsampledErrorBounds() {
-		ExactRelation r = new ProjectedRelation(vc, source.rewriteWithSubsampledErrorBounds(), elems);
+		ExactRelation newSource = source.rewriteWithSubsampledErrorBounds();
+		List<SelectElem> sourceElems = newSource.getSelectList();
+		Set<String> colAliases = new HashSet<String>();
+		for (SelectElem e : sourceElems) {
+			if (e.aliasPresent()) {
+				// we're only interested in the columns for which aliases are present.
+				// note that every column with aggregate function must have an alias (enforced by ColNameExpr class).
+				colAliases.add(e.getAlias());
+			}
+		}
+		
+		// we look for error bound columns based on the assumption that the error bound columns have the suffix attached
+		// to the original agg columns. The suffix is obtained from the ApproxRelation#errColSuffix() method.
+		// ApproxAggregatedRelation#rewriteWithSubsampledErrorBounds() method is responsible for having those columns. 
+		List<SelectElem> elemsWithErr = new ArrayList<SelectElem>();
+		for (SelectElem e : elems) {
+			elemsWithErr.add(e);
+			String errColName = e.getExpr().toString() + errColSuffix();
+			if (colAliases.contains(errColName)) {
+				elemsWithErr.add(new SelectElem(new ColNameExpr(errColName), errColName));
+			}
+		}
+		
+		ExactRelation r = new ProjectedRelation(vc, newSource, elemsWithErr);
 		r.setAliasName(getAliasName());
 		return r;
 	}
@@ -78,5 +106,5 @@ public class ApproxProjectedRelation extends ApproxRelation {
 	protected List<String> sampleColumns() {
 		return source.sampleColumns();
 	}
-
+	
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
@@ -133,9 +133,9 @@ public abstract class ApproxRelation extends Relation {
 	 */
 	protected abstract ExactRelation rewriteWithPartition();
 	
-	protected String partitionColumnName() {
-		return vc.getDbms().partitionColumnName();
-	}
+//	protected String partitionColumnName() {
+//		return vc.getDbms().partitionColumnName();
+//	}
 	
 	// returns effective partition column name for a possibly joined table.
 //	protected abstract ColNameExpr partitionColumn();
@@ -179,7 +179,7 @@ public abstract class ApproxRelation extends Relation {
 	 */
 	protected abstract String sampleType();
 	
-	protected abstract List<TableUniqueName> accumulateStratifiedSamples();
+//	protected abstract List<ColNameExpr> accumulateSamplingProbColumns();
 	
 	/**
 	 * Returns a set of columns on which a sample is created. Only meaningful for stratified and universe samples.

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
@@ -124,7 +124,6 @@ public abstract class ApproxRelation extends Relation {
 	
 	
 	public ExactRelation rewriteWithSubsampledErrorBounds() {
-		
 		VerdictLogger.error(this, String.format("Calling a method, %s, on unappropriate class", "rewriteWithSubsampledErrorBounds()"));
 		return null;
 	}

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
@@ -171,7 +171,7 @@ public abstract class ApproxRelation extends Relation {
 	 * @param f
 	 * @return
 	 */
-	protected abstract double samplingProbabilityFor(FuncExpr f);
+	protected abstract List<Expr> samplingProbabilityExprsFor(FuncExpr f);
 	
 	/**
 	 * Returns an effective sample type of this relation.

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
@@ -122,7 +122,9 @@ public abstract class ApproxRelation extends Relation {
 	
 	public abstract ExactRelation rewriteForPointEstimate();
 	
+	
 	public ExactRelation rewriteWithSubsampledErrorBounds() {
+		
 		VerdictLogger.error(this, String.format("Calling a method, %s, on unappropriate class", "rewriteWithSubsampledErrorBounds()"));
 		return null;
 	}

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
@@ -30,6 +30,10 @@ public abstract class ApproxRelation extends Relation {
 		approximate = true;
 	}
 	
+	public String errColSuffix() {
+		return "_err";
+	}
+	
 	public String sourceTableName() {
 		if (this instanceof ApproxSingleRelation) {
 			ApproxSingleRelation r = (ApproxSingleRelation) this;
@@ -188,6 +192,7 @@ public abstract class ApproxRelation extends Relation {
 	 * @return
 	 */
 	protected abstract Map<String, String> tableSubstitution();
+	
 	
 	/*
 	 * order by and limit

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxRelation.java
@@ -134,11 +134,11 @@ public abstract class ApproxRelation extends Relation {
 	protected abstract ExactRelation rewriteWithPartition();
 	
 	protected String partitionColumnName() {
-		return vc.getConf().get("verdict.partition_column_name");
+		return vc.getDbms().partitionColumnName();
 	}
 	
 	// returns effective partition column name for a possibly joined table.
-	protected abstract ColNameExpr partitionColumn();
+//	protected abstract ColNameExpr partitionColumn();
 	
 	public ExactRelation rewriteWithBootstrappedErrorBounds() { return null; }
 	
@@ -233,7 +233,7 @@ public abstract class ApproxRelation extends Relation {
 					return new ColNameExpr(e.getCol(), sub.get(e.getTab()), e.getSchema());
 				} else if (expr instanceof FuncExpr) {
 					FuncExpr e = (FuncExpr) expr;
-					return new FuncExpr(e.getFuncName(), visit(e.getExpr()));
+					return new FuncExpr(e.getFuncName(), visit(e.getUnaryExpr()));
 				} else {
 					return expr;
 				}

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxSingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxSingleRelation.java
@@ -116,16 +116,16 @@ public class ApproxSingleRelation extends ApproxRelation {
 	
 	@Override
 	public ExactRelation rewriteWithPartition() {
-		ExactRelation r = SingleRelation.from(vc, getSampleName());
+		ExactRelation r = vc.getDbms().augmentWithRandomPartitionNum(SingleRelation.from(vc, getSampleName()));
 		r.setAliasName(getAliasName());
 		return r;
 	}
 	
-	@Override
-	protected ColNameExpr partitionColumn() {
-		String col = partitionColumnName();
-		return new ColNameExpr(col, getTableName().tableName);
-	}
+//	@Override
+//	protected ColNameExpr partitionColumn() {
+//		String col = partitionColumnName();
+//		return new ColNameExpr(col, getTableName().tableName);
+//	}
 
 	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {

--- a/core/src/main/java/edu/umich/verdict/relation/ApproxSingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ApproxSingleRelation.java
@@ -155,15 +155,6 @@ public class ApproxSingleRelation extends ApproxRelation {
 	}
 	
 	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		if (param.sampleType.equals("stratified")) {
-			return Arrays.asList(param.sampleTableName());
-		} else {
-			return Arrays.asList();
-		}
-	}
-	
-	@Override
 	protected List<String> sampleColumns() {
 		return param.columnNames;
 	}

--- a/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
@@ -370,9 +370,7 @@ public abstract class ExactRelation extends Relation {
 	 */
 	public abstract ColNameExpr partitionColumn();
 	
-	public String partitionColumnName() {
-		
-	}
+	public abstract List<ColNameExpr> accumulateSamplingProbColumns();
 	
 }
 

--- a/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
@@ -363,6 +363,16 @@ public abstract class ExactRelation extends Relation {
 	public List<SelectElem> selectElemsWithAggregateSource() {
 		return new ArrayList<SelectElem>();
 	}
+
+	/**
+	 * Used for subsampling-based error estimation. Should return the partition column of this instance.
+	 * @return
+	 */
+	public abstract ColNameExpr partitionColumn();
+	
+	public String partitionColumnName() {
+		
+	}
 	
 }
 

--- a/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
@@ -74,6 +74,9 @@ public abstract class ExactRelation extends Relation {
 	 */
 	protected abstract String getSourceName();
 	
+	public abstract List<SelectElem> getSelectList();
+	
+	
 	/*
 	 * Projection
 	 */

--- a/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
@@ -344,7 +344,10 @@ public abstract class ExactRelation extends Relation {
 
 	protected String sourceExpr(ExactRelation source) {
 		if (source instanceof SingleRelation) {
-			return ((SingleRelation) source).getTableName().tableName;
+			SingleRelation asource = (SingleRelation) source;
+			String tableName = asource.getTableName().tableName;
+			String alias = asource.getAliasName();
+			return String.format("%s AS %s", tableName, alias);
 		} else if (source instanceof JoinedRelation) {
 			return ((JoinedRelation) source).joinClause();
 		} else {

--- a/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
@@ -12,6 +12,7 @@ import edu.umich.verdict.datatypes.SampleParam;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.condition.Cond;
+import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.SelectElem;
 
 public class FilteredRelation extends ExactRelation {
@@ -76,6 +77,13 @@ public class FilteredRelation extends ExactRelation {
 	@Override
 	public List<SelectElem> getSelectList() {
 		return source.getSelectList();
+	}
+
+	@Override
+	public ColNameExpr partitionColumn() {
+		ColNameExpr col = source.partitionColumn();
+		col.setTab(getAliasName());
+		return col;
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
@@ -25,6 +25,7 @@ public class FilteredRelation extends ExactRelation {
 		super(vc);
 		this.source = source;
 		this.cond = cond;
+		this.alias = source.alias;
 	}
 
 	public ExactRelation getSource() {
@@ -84,6 +85,11 @@ public class FilteredRelation extends ExactRelation {
 		ColNameExpr col = source.partitionColumn();
 		col.setTab(getAliasName());
 		return col;
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		return source.accumulateSamplingProbColumns();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
@@ -73,4 +73,9 @@ public class FilteredRelation extends ExactRelation {
 		return sql.toString();
 	}
 
+	@Override
+	public List<SelectElem> getSelectList() {
+		return source.getSelectList();
+	}
+
 }

--- a/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/FilteredRelation.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 
 import edu.umich.verdict.VerdictContext;
@@ -92,4 +93,12 @@ public class FilteredRelation extends ExactRelation {
 		return source.accumulateSamplingProbColumns();
 	}
 
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAliasName(), cond.toString()));
+		s.append(source.toStringWithIndent(indent + "  "));
+		return s.toString();
+	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
@@ -100,11 +100,8 @@ public class GroupedRelation extends ExactRelation {
 		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT * ");
 		
-		StringBuilder gsql = new StringBuilder();
 		Pair<List<Expr>, ExactRelation> groupsAndNextR = allPrecedingGroupbys(this.source);
-		for (Expr e : groupsAndNextR.getLeft()) {
-			gsql.append(e);
-		}
+		String gsql = Joiner.on(", ").join(groupsAndNextR.getLeft());
 		
 		Pair<Optional<Cond>, ExactRelation> filtersAndNextR = allPrecedingFilters(groupsAndNextR.getRight());
 		String csql = (filtersAndNextR.getLeft().isPresent())? filtersAndNextR.getLeft().get().toString() : "";
@@ -113,6 +110,11 @@ public class GroupedRelation extends ExactRelation {
 		if (csql.length() > 0) { sql.append(" WHERE "); sql.append(csql); }
 		if (gsql.length() > 0) { sql.append(" GROUP BY "); sql.append(gsql); }
 		return sql.toString();
+	}
+
+	@Override
+	public List<SelectElem> getSelectList() {
+		return source.getSelectList();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
@@ -117,4 +117,11 @@ public class GroupedRelation extends ExactRelation {
 		return source.getSelectList();
 	}
 
+	@Override
+	public ColNameExpr partitionColumn() {
+		ColNameExpr col = source.partitionColumn();
+		col.setTab(getAliasName());
+		return col;
+	}
+
 }

--- a/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
@@ -30,7 +30,15 @@ public class GroupedRelation extends ExactRelation {
 	public GroupedRelation(VerdictContext vc, ExactRelation source, List<ColNameExpr> groupby) {
 		super(vc);
 		this.source = source;
-		this.groupby = groupby;
+		List<ColNameExpr> groupbyWithSource = new ArrayList<ColNameExpr>();
+		for (ColNameExpr expr : groupby) {
+			if (expr.getTab() == null) {
+				groupbyWithSource.add(new ColNameExpr(expr.getCol(), source.getAliasName()));
+			} else {
+				groupbyWithSource.add(expr);
+			}
+		}
+		this.groupby = groupbyWithSource;
 		this.alias = source.alias;
 	}
 	
@@ -128,6 +136,15 @@ public class GroupedRelation extends ExactRelation {
 	@Override
 	public List<ColNameExpr> accumulateSamplingProbColumns() {
 		return source.accumulateSamplingProbColumns();
+	}
+	
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAliasName(), Joiner.on(", ").join(groupby)));
+		s.append(source.toStringWithIndent(indent + "  "));
+		return s.toString();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/GroupedRelation.java
@@ -31,6 +31,7 @@ public class GroupedRelation extends ExactRelation {
 		super(vc);
 		this.source = source;
 		this.groupby = groupby;
+		this.alias = source.alias;
 	}
 	
 	public ExactRelation getSource() {
@@ -122,6 +123,11 @@ public class GroupedRelation extends ExactRelation {
 		ColNameExpr col = source.partitionColumn();
 		col.setTab(getAliasName());
 		return col;
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		return source.accumulateSamplingProbColumns();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
@@ -244,4 +244,12 @@ public class JoinedRelation extends ExactRelation {
 		VerdictLogger.error(this, "The source name of a joined table should not be called.");
 		return null;
 	}
+
+	@Override
+	public List<SelectElem> getSelectList() {
+		List<SelectElem> elems = new ArrayList<SelectElem>();
+		elems.addAll(source1.getSelectList());
+		elems.addAll(source2.getSelectList());
+		return elems;
+	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
@@ -40,6 +40,8 @@ public class JoinedRelation extends ExactRelation {
 		} else {
 			this.joinCols = joinCols;
 		}
+		
+		this.alias = null;
 	}
 	
 	public static JoinedRelation from(VerdictContext vc, ExactRelation source1, ExactRelation source2, List<Pair<Expr, Expr>> joinCols) {
@@ -260,5 +262,12 @@ public class JoinedRelation extends ExactRelation {
 		} else {
 			return col2;
 		}
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		List<ColNameExpr> union = new ArrayList<ColNameExpr>(source1.accumulateSamplingProbColumns());
+		union.addAll(source2.accumulateSamplingProbColumns());
+		return union;
 	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 
 import edu.umich.verdict.VerdictContext;
@@ -86,7 +87,7 @@ public class JoinedRelation extends ExactRelation {
 		StringBuilder sql = new StringBuilder(100);
 		
 		if (joinCols == null || joinCols.size() == 0) {
-			VerdictLogger.info(this, "No join conditions specified; cross join is used.");
+			VerdictLogger.debug(this, "No join conditions specified; cross join is used.");
 			sql.append(String.format("%s CROSS JOIN %s", sourceExpr(source1), sourceExpr(source2)));
 		} else {
 			sql.append(String.format("%s INNER JOIN %s ON", sourceExpr(source1), sourceExpr(source2)));
@@ -269,5 +270,15 @@ public class JoinedRelation extends ExactRelation {
 		List<ColNameExpr> union = new ArrayList<ColNameExpr>(source1.accumulateSamplingProbColumns());
 		union.addAll(source2.accumulateSamplingProbColumns());
 		return union;
+	}
+	
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAliasName(), Joiner.on(", ").join(joinCols)));
+		s.append(source1.toStringWithIndent(indent + "  "));
+		s.append(source2.toStringWithIndent(indent + "  "));
+		return s.toString();
 	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
@@ -234,9 +234,7 @@ public class JoinedRelation extends ExactRelation {
 	 */
 	
 	public String toSql() {
-		StringBuilder sql = new StringBuilder();
-		sql.append(String.format("SELECT * FROM %s", joinClause()));
-		return sql.toString();
+		return this.select("*").toSql();
 	}
 
 	@Override
@@ -251,5 +249,16 @@ public class JoinedRelation extends ExactRelation {
 		elems.addAll(source1.getSelectList());
 		elems.addAll(source2.getSelectList());
 		return elems;
+	}
+
+	@Override
+	public ColNameExpr partitionColumn() {
+		ColNameExpr col1 = source1.partitionColumn();
+		ColNameExpr col2 = source2.partitionColumn();
+		if (col1 != null) {
+			return col1;
+		} else {
+			return col2;
+		}
 	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
@@ -26,6 +26,7 @@ public class LimitedRelation extends ExactRelation {
 		super(vc);
 		this.source = source;
 		this.limit = limit;
+		this.alias = source.alias;
 	}
 	
 	public ExactRelation getSource() {
@@ -67,6 +68,11 @@ public class LimitedRelation extends ExactRelation {
 		ColNameExpr col = source.partitionColumn();
 		col.setTab(getAliasName());
 		return col;
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		return source.accumulateSamplingProbColumns();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
@@ -13,6 +13,7 @@ import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.OrderByExpr;
+import edu.umich.verdict.relation.expr.SelectElem;
 
 public class LimitedRelation extends ExactRelation {
 	
@@ -53,6 +54,11 @@ public class LimitedRelation extends ExactRelation {
 		sql.append(source.toSql());
 		sql.append(" LIMIT " + limit);
 		return sql.toString();
+	}
+
+	@Override
+	public List<SelectElem> getSelectList() {
+		return source.getSelectList();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
@@ -11,6 +11,7 @@ import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.SampleParam;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.OrderByExpr;
 import edu.umich.verdict.relation.expr.SelectElem;
@@ -59,6 +60,13 @@ public class LimitedRelation extends ExactRelation {
 	@Override
 	public List<SelectElem> getSelectList() {
 		return source.getSelectList();
+	}
+
+	@Override
+	public ColNameExpr partitionColumn() {
+		ColNameExpr col = source.partitionColumn();
+		col.setTab(getAliasName());
+		return col;
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/LimitedRelation.java
@@ -74,5 +74,14 @@ public class LimitedRelation extends ExactRelation {
 	public List<ColNameExpr> accumulateSamplingProbColumns() {
 		return source.accumulateSamplingProbColumns();
 	}
+	
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%d]\n", this.getClass().getSimpleName(), getAliasName(), limit));
+		s.append(source.toStringWithIndent(indent + "  "));
+		return s.toString();
+	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
@@ -1,6 +1,7 @@
 package edu.umich.verdict.relation;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,11 +42,6 @@ public class NoApproxRelation extends ApproxRelation {
 	@Override
 	protected String sampleType() {
 		return "nosample";
-	}
-
-	@Override
-	protected List<TableUniqueName> accumulateStratifiedSamples() {
-		return new ArrayList<TableUniqueName>();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.relation.expr.ColNameExpr;
+import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.FuncExpr;
 
 public class NoApproxRelation extends ApproxRelation {
@@ -35,8 +36,8 @@ public class NoApproxRelation extends ApproxRelation {
 	}
 
 	@Override
-	protected double samplingProbabilityFor(FuncExpr f) {
-		return 1.0;
+	protected List<Expr> samplingProbabilityExprsFor(FuncExpr f) {
+		return Arrays.asList();
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
@@ -1,0 +1,66 @@
+package edu.umich.verdict.relation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.relation.expr.ColNameExpr;
+import edu.umich.verdict.relation.expr.FuncExpr;
+
+public class NoApproxRelation extends ApproxRelation {
+	
+	ExactRelation r;
+
+	public NoApproxRelation(ExactRelation r) {
+		super(r.vc);
+		this.r = r;
+	}
+	
+	@Override
+	public ExactRelation rewriteWithSubsampledErrorBounds() {
+		return r;
+	}
+
+	@Override
+	public ExactRelation rewriteForPointEstimate() {
+		return r;
+	}
+
+	@Override
+	protected ExactRelation rewriteWithPartition() {
+		return r;
+	}
+
+	@Override
+	protected ColNameExpr partitionColumn() {
+		return null;
+	}
+
+	@Override
+	protected double samplingProbabilityFor(FuncExpr f) {
+		return 1.0;
+	}
+
+	@Override
+	protected String sampleType() {
+		return "nosample";
+	}
+
+	@Override
+	protected List<TableUniqueName> accumulateStratifiedSamples() {
+		return new ArrayList<TableUniqueName>();
+	}
+
+	@Override
+	protected List<String> sampleColumns() {
+		return new ArrayList<String>();
+	}
+
+	@Override
+	protected Map<String, String> tableSubstitution() {
+		return new HashMap<String, String>();
+	}
+
+}

--- a/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/NoApproxRelation.java
@@ -34,11 +34,6 @@ public class NoApproxRelation extends ApproxRelation {
 	}
 
 	@Override
-	protected ColNameExpr partitionColumn() {
-		return null;
-	}
-
-	@Override
 	protected double samplingProbabilityFor(FuncExpr f) {
 		return 1.0;
 	}

--- a/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
@@ -11,6 +11,7 @@ import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.datatypes.SampleParam;
 import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.expr.ColNameExpr;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.OrderByExpr;
 import edu.umich.verdict.relation.expr.SelectElem;
@@ -57,6 +58,13 @@ public class OrderedRelation extends ExactRelation {
 	@Override
 	public List<SelectElem> getSelectList() {
 		return source.getSelectList();
+	}
+
+	@Override
+	public ColNameExpr partitionColumn() {
+		ColNameExpr col = source.partitionColumn();
+		col.setTab(getAliasName());
+		return col;
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
@@ -27,6 +27,7 @@ public class OrderedRelation extends ExactRelation {
 		this.source = source;
 		this.orderby = orderby;
 		subquery = true;
+		this.alias = source.alias;
 	}
 
 	@Override
@@ -65,6 +66,11 @@ public class OrderedRelation extends ExactRelation {
 		ColNameExpr col = source.partitionColumn();
 		col.setTab(getAliasName());
 		return col;
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		return source.accumulateSamplingProbColumns();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
@@ -72,5 +72,14 @@ public class OrderedRelation extends ExactRelation {
 	public List<ColNameExpr> accumulateSamplingProbColumns() {
 		return source.accumulateSamplingProbColumns();
 	}
+	
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAliasName(), Joiner.on(", ").join(orderby)));
+		s.append(source.toStringWithIndent(indent + "  "));
+		return s.toString();
+	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/OrderedRelation.java
@@ -13,6 +13,7 @@ import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.relation.expr.Expr;
 import edu.umich.verdict.relation.expr.OrderByExpr;
+import edu.umich.verdict.relation.expr.SelectElem;
 
 public class OrderedRelation extends ExactRelation {
 	
@@ -51,6 +52,11 @@ public class OrderedRelation extends ExactRelation {
 		sql.append(" ORDER BY ");
 		sql.append(Joiner.on(", ").join(orderby));
 		return sql.toString();
+	}
+
+	@Override
+	public List<SelectElem> getSelectList() {
+		return source.getSelectList();
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/PartitionedApproxSingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/PartitionedApproxSingleRelation.java
@@ -1,0 +1,19 @@
+package edu.umich.verdict.relation;
+
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.datatypes.SampleParam;
+import edu.umich.verdict.datatypes.SampleSizeInfo;
+import edu.umich.verdict.datatypes.TableUniqueName;
+
+public class PartitionedApproxSingleRelation extends ApproxSingleRelation {
+
+	protected PartitionedApproxSingleRelation(VerdictContext vc, SampleParam param) {
+		super(vc, param);
+	}
+
+	protected PartitionedApproxSingleRelation(VerdictContext vc, TableUniqueName sampleTableName, SampleParam param,
+			SampleSizeInfo info) {
+		super(vc, sampleTableName, param, info);
+	}
+
+}

--- a/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
@@ -121,4 +121,13 @@ public class ProjectedRelation extends ExactRelation {
 		return aggElems;
 	}
 
+	@Override
+	public ColNameExpr partitionColumn() {
+		
+		
+		ColNameExpr col = source.partitionColumn();
+		col.setTab(getAliasName());
+		return col;
+	}
+
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
@@ -123,11 +123,32 @@ public class ProjectedRelation extends ExactRelation {
 
 	@Override
 	public ColNameExpr partitionColumn() {
+		String pcol = partitionColumnName();
+		ColNameExpr col = null;
 		
+		// first inspect if there is a randomly generated partition column in this instance's projection list
+		for (SelectElem elem : elems) {
+			String alias = elem.getAlias();
+			if (alias != null && alias.equals(pcol)) {
+				col = new ColNameExpr(pcol, getAliasName());
+			}
+		}
 		
-		ColNameExpr col = source.partitionColumn();
-		col.setTab(getAliasName());
+		if (col == null) {
+			col = source.partitionColumn();
+		}
+		
 		return col;
+	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		List<ColNameExpr> exprs = source.accumulateSamplingProbColumns();
+		List<ColNameExpr> exprsInNewTable = new ArrayList<ColNameExpr>(); 
+		for (ColNameExpr c : exprs) {
+			exprsInNewTable.add(new ColNameExpr(c.getCol(), getAliasName()));
+		}
+		return exprsInNewTable;
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
@@ -150,5 +150,14 @@ public class ProjectedRelation extends ExactRelation {
 		}
 		return exprsInNewTable;
 	}
+	
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s) [%s]\n", this.getClass().getSimpleName(), getAliasName(), Joiner.on(", ").join(elems)));
+		s.append(source.toStringWithIndent(indent + "  "));
+		return s.toString();
+	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/Relation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/Relation.java
@@ -281,10 +281,11 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 		
 		if (ctx.group_by_item() != null && ctx.group_by_item().size() > 0) {
 			query.append("\n" + indent + "GROUP BY ");
+			List<String> groupby = new ArrayList<String>();
 			for (VerdictSQLParser.Group_by_itemContext gctx : ctx.group_by_item()) {
-				query.append(visit(gctx));
+				groupby.add(visit(gctx));
 			}
-			query.append(" ");
+			query.append(Joiner.on(", ").join(groupby));
 		}
 		
 		String sql = query.toString();
@@ -524,6 +525,7 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 		else if (op.equals("+")) return leftCol + " + " + rightCol;
 		else if (op.equals("/")) return leftCol + " / " + rightCol;
 		else if (op.equals("-")) return leftCol + " - " + rightCol;
+		else if (op.equals("%")) return leftCol + " % " + rightCol;
 		else return null;
 	}
 	

--- a/core/src/main/java/edu/umich/verdict/relation/Relation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/Relation.java
@@ -606,14 +606,14 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 		if (ctx.as_table_alias() == null) {
 			return tableNameItem;
 		} else {
-			String alias = ctx.as_table_alias().getText();
+			String alias = ctx.as_table_alias().table_alias().getText();
 			return tableNameItem + " " + alias;
 		}
 	}
 	
 	@Override
 	public String visitDerived_table_source_item(VerdictSQLParser.Derived_table_source_itemContext ctx) {
-		return String.format("(\n%s) AS %s", visit(ctx.derived_table().subquery()), ctx.as_table_alias().table_alias().getText());
+		return String.format("(\n%s) %s", visit(ctx.derived_table().subquery()), ctx.as_table_alias().table_alias().getText());
 	}
 	
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/Relation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/Relation.java
@@ -486,13 +486,28 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 		return FuncExpr.from(ctx.function_call()).toString();
 	}
 	
-	@Override public String visitMathematical_function_expression(VerdictSQLParser.Mathematical_function_expressionContext ctx)
-	{
-		if (ctx.expression() != null) {
-			return String.format("%s(%s)", ctx.unary_mathematical_function().getText(), visit(ctx.expression()));
-		} else {
-			return String.format("%s()", ctx.noparam_mathematical_function().getText());
-		}
+//	@Override public String visitMathematical_function_expression(VerdictSQLParser.Mathematical_function_expressionContext ctx)
+//	{
+//		if (ctx.expression() != null) {
+//			return String.format("%s(%s)", ctx.unary_mathematical_function().getText(), visit(ctx.expression()));
+//		} else {
+//			return String.format("%s()", ctx.noparam_mathematical_function().getText());
+//		}
+//	}
+	
+	@Override
+	public String visitUnary_mathematical_function(VerdictSQLParser.Unary_mathematical_functionContext ctx) {
+		return String.format("%s(%s)", ctx.getText(), visit(ctx.expression()));
+	}
+	
+	@Override
+	public String visitNoparam_mathematical_function(VerdictSQLParser.Noparam_mathematical_functionContext ctx) {
+		return String.format("%s()", ctx.getText());
+	}
+	
+	@Override
+	public String visitBinary_mathematical_function(VerdictSQLParser.Binary_mathematical_functionContext ctx) {
+		return String.format("%s(%s, %s)", ctx.getText(), visit(ctx.expression(0)), visit(ctx.expression(1)));
 	}
 	
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/Relation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/Relation.java
@@ -328,12 +328,14 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 		if (ctx.getText().equals("*")) {
 			return "*";
 		} else {
-			StringBuilder elem = new StringBuilder();
-			elem.append(visit(ctx.expression()));
-			if (ctx.column_alias() != null) {
-				elem.append(String.format(" AS %s", ctx.column_alias().getText()));
-			}
-			return elem.toString();
+//			StringBuilder elem = new StringBuilder();
+//			elem.append(visit(ctx.expression()));
+//			if (ctx.column_alias() != null) {
+//				elem.append(String.format(" AS %s", ctx.column_alias().getText()));
+//			}
+			Expr expr = Expr.from(ctx.expression());
+			String alias = (ctx.column_alias() == null)? null : ctx.column_alias().getText();
+			return (new SelectElem(expr, alias)).toString();
 		}
 	}
 	
@@ -583,14 +585,14 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 	@Override
 	public String visitJoin_part(VerdictSQLParser.Join_partContext ctx) {
 		if (ctx.INNER() != null) {
-			return "\n" + indent + "     " + String.format("INNER JOIN %s ", visit(ctx.table_source()))
-				 + "\n" + indent + "     " + String.format("ON %s", visit(ctx.search_condition()));
+			return "\n" + indent + "  " + String.format("INNER JOIN %s ", visit(ctx.table_source()))
+				 + "\n" + indent + "  " + String.format("ON %s", visit(ctx.search_condition()));
 		} else if (ctx.OUTER() != null) {
-			return String.format("%s OUTER JOIN %s ON %s", ctx.join_type.getText(), visit(ctx.table_source()), visit(ctx.search_condition()));
+			return "\n" + indent + "  " + String.format("%s OUTER JOIN %s ON %s", ctx.join_type.getText(), visit(ctx.table_source()), visit(ctx.search_condition()));
 		} else if (ctx.CROSS() != null) {
-			return String.format("CROSS JOIN %s", visit(ctx.table_source()));
+			return "\n" + indent + "  " + String.format("CROSS JOIN %s", visit(ctx.table_source()));
 		} else {
-			return String.format("UNSUPPORTED JOIN (%s)", ctx.getText());
+			return "\n" + indent + "  " + String.format("UNSUPPORTED JOIN (%s)", ctx.getText());
 		}
 	}
 	

--- a/core/src/main/java/edu/umich/verdict/relation/Relation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/Relation.java
@@ -206,6 +206,14 @@ public abstract class Relation {
 		return TableUniqueName.uname(vc, n);
 	}
 	
+	public String partitionColumnName() {
+		return vc.getDbms().partitionColumnName();
+	}
+	
+	public String samplingProbabilityColumnName() {
+		return vc.getConf().get("verdict.sampling_probability_column");
+	}
+	
 }
 
 

--- a/core/src/main/java/edu/umich/verdict/relation/Relation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/Relation.java
@@ -211,7 +211,7 @@ public abstract class Relation {
 	}
 	
 	public String samplingProbabilityColumnName() {
-		return vc.getConf().get("verdict.sampling_probability_column");
+		return vc.getDbms().samplingProbabilityColumnName();
 	}
 	
 }
@@ -562,7 +562,7 @@ class PrettyPrintVisitor extends VerdictSQLBaseVisitor<String> {
 	
 	@Override
 	public String visitSubquery_expression(VerdictSQLParser.Subquery_expressionContext ctx) {
-		return "(\n" + indent + visit(ctx.subquery()) + ")";
+		return "(\n" + visit(ctx.subquery()) + ")";
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/SampleGroup.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SampleGroup.java
@@ -1,6 +1,7 @@
 package edu.umich.verdict.relation;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -68,7 +69,7 @@ public class SampleGroup {
 	
 	@Override
 	public String toString() {
-		return samples.toString();
+		return samples.toString() + "=>" + elems.toString();
 	}
 	
 	public boolean isEqualSample(SampleGroup o) {
@@ -81,5 +82,11 @@ public class SampleGroup {
 	
 	public Pair<Set<SampleParam>, List<SelectElem>> unroll() {
 		return Pair.of(samples, elems);
+	}
+	
+	public SampleGroup duplicate() {
+		Set<SampleParam> copiedSamples = new HashSet<SampleParam>(samples);
+		List<SelectElem> copiedElems = new ArrayList<SelectElem>(elems);
+		return new SampleGroup(copiedSamples, copiedElems, samplingProb, cost);
 	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SamplePlan.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SamplePlan.java
@@ -11,8 +11,8 @@ import edu.umich.verdict.relation.expr.SelectElem;
 
 /**
  * Stores information about what samples to use to compute multiple expressions. A single SampleGroup instance stores
- * the mapping from a set of samples to a list of expressions to answer using the set, and this class multiple number
- * of such SampleGroup instances.
+ * the mapping from a set of samples to a list of expressions to answer using the set, and this class includes multiple number
+ * of such SampleGroup instances so that they can answer the user-submitted query when combined.
  * @author Yongjoo Park
  */
 public class SamplePlan {
@@ -33,7 +33,7 @@ public class SamplePlan {
 	public SamplePlan duplicate() {
 		List<SampleGroup> copy = new ArrayList<SampleGroup>();
 		for (SampleGroup g : sampleGroups) {
-			copy.add(g);
+			copy.add(g.duplicate());
 		}
 		return new SamplePlan(copy);
 	}
@@ -45,6 +45,14 @@ public class SamplePlan {
 	@Override
 	public String toString() {
 		return sampleGroups.toString();
+	}
+	
+	public String toPrettyString() {
+		StringBuilder s = new StringBuilder();
+		for (SampleGroup g : sampleGroups) {
+			s.append(g.toString()); s.append("\n");
+		}
+		return s.toString();
 	}
 	
 	public double cost() {

--- a/core/src/main/java/edu/umich/verdict/relation/SamplePlans.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SamplePlans.java
@@ -99,16 +99,17 @@ public class SamplePlans {
 
 		// find the best plan (the plan whose cost is not too large and its sampling prob is good)
 		SamplePlan best = null;
-		double bestSamplingProb = Double.NEGATIVE_INFINITY;
+		double bestScore = Double.NEGATIVE_INFINITY;
 		for (SamplePlan plan : plans) {
 			double cost = plan.cost();
 			if (cost < original_cost * relative_cost_ratio) {
 				double samplingProb = plan.harmonicSamplingProb();
-				if (samplingProb > bestSamplingProb) {
-					bestSamplingProb = samplingProb;
+				double thisScore = computeScore(cost, samplingProb);
+				if (thisScore > bestScore) {
+					bestScore = thisScore;
 					best = plan;
 				}
-				VerdictLogger.debug(this, plan.toString() + ", cost: " + cost + ", prob: " + plan.harmonicSamplingProb());
+//				VerdictLogger.debug(this, plan.toString() + ", cost: " + cost + ", prob: " + plan.harmonicSamplingProb());
 			}
 		}
 
@@ -117,6 +118,10 @@ public class SamplePlans {
 		} else {
 			return original_plan;
 		}
+	}
+	
+	private double computeScore(double cost, double samplingProbability) {
+		return samplingProbability / Math.sqrt(cost);
 	}
 
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -277,5 +277,16 @@ public class SingleRelation extends ExactRelation {
 	protected SampleParam asSampleParam() {
 		return new SampleParam(getTableName(), NOSAMPLE, 1.0, null);
 	}
+
+	@Override
+	public List<SelectElem> getSelectList() {
+		TableUniqueName table = getTableName();
+		List<String> columns = vc.getMeta().getColumnNames(table);
+		List<SelectElem> elems = new ArrayList<SelectElem>();
+		for (String c : columns) {
+			elems.add(new SelectElem(new ColNameExpr(c, table.tableName)));
+		}
+		return elems;
+	}
 	
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 
 import edu.umich.verdict.VerdictContext;
@@ -305,4 +306,11 @@ public class SingleRelation extends ExactRelation {
 		return samplingProbCols;
 	}
 	
+	@Override
+	protected String toStringWithIndent(String indent) {
+		StringBuilder s = new StringBuilder(1000);
+		s.append(indent);
+		s.append(String.format("%s(%s, %s)\n", this.getClass().getSimpleName(), getTableName(), getAliasName()));
+		return s.toString();
+	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -136,9 +136,9 @@ public class SingleRelation extends ExactRelation {
 		Set<String> cols = new HashSet<String>(vc.getMeta().getColumnNames(getTableName()));
 		List<Double> probs = new ArrayList<Double>();
 		for (FuncExpr fexpr : funcs) {
-			String fcol = fexpr.getExprInString();
-			if (fexpr.getExpr() instanceof ColNameExpr) {
-				fcol = ((ColNameExpr) fexpr.getExpr()).getCol();
+			String fcol = fexpr.getUnaryExprInString();
+			if (fexpr.getUnaryExpr() instanceof ColNameExpr) {
+				fcol = ((ColNameExpr) fexpr.getUnaryExpr()).getCol();
 			}
 			
 			if (fexpr.getFuncName().equals(FuncExpr.FuncName.COUNT_DISTINCT)) {
@@ -287,6 +287,11 @@ public class SingleRelation extends ExactRelation {
 			elems.add(new SelectElem(new ColNameExpr(c, table.tableName)));
 		}
 		return elems;
+	}
+
+	@Override
+	public ColNameExpr partitionColumn() {
+		return null;
 	}
 	
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -293,5 +293,18 @@ public class SingleRelation extends ExactRelation {
 	public ColNameExpr partitionColumn() {
 		return null;
 	}
+
+	@Override
+	public List<ColNameExpr> accumulateSamplingProbColumns() {
+		List<ColNameExpr> samplingProbCols = new ArrayList<ColNameExpr>();
+		List<String> cols = vc.getMeta().getColumnNames(tableName);
+		String samplingProbColName = samplingProbabilityColumnName();
+		for (String c : cols) {
+			if (c.equals(samplingProbColName)) {
+				samplingProbCols.add(new ColNameExpr(samplingProbColName, tableName.tableName));
+			}
+		}
+		return samplingProbCols;
+	}
 	
 }

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -50,9 +50,7 @@ public class SingleRelation extends ExactRelation {
 	
 	@Override
 	public String toSql() {
-		StringBuilder sql = new StringBuilder();
-		sql.append("SELECT * FROM " + tableName);
-		return sql.toString();
+		return select("*").toSql();
 	}
 	
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/SingleRelation.java
@@ -289,7 +289,7 @@ public class SingleRelation extends ExactRelation {
 
 	@Override
 	public ColNameExpr partitionColumn() {
-		return null;
+		return new ColNameExpr(vc.getDbms().partitionColumnName(), getAliasName());
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/condition/AndCond.java
+++ b/core/src/main/java/edu/umich/verdict/relation/condition/AndCond.java
@@ -29,7 +29,7 @@ public class AndCond extends Cond {
 	
 	@Override
 	public Cond accept(CondModifier v) {
-		return v.call(this);
+		return from(left.accept(v), right.accept(v));
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/condition/OrCond.java
+++ b/core/src/main/java/edu/umich/verdict/relation/condition/OrCond.java
@@ -15,6 +15,27 @@ public class OrCond extends Cond {
 		return new OrCond(left, right);
 	}
 
+	public Cond getLeft() {
+		return left;
+	}
+
+	public void setLeft(Cond left) {
+		this.left = left;
+	}
+
+	public Cond getRight() {
+		return right;
+	}
+
+	public void setRight(Cond right) {
+		this.right = right;
+	}
+
+	@Override
+	public Cond accept(CondModifier v) {
+		return from(left.accept(v), right.accept(v));
+	}
+
 	@Override
 	public String toString() {
 		return String.format("(%s) OR (%s)", left.toString(), right.toString());

--- a/core/src/main/java/edu/umich/verdict/relation/expr/ColNameExpr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/ColNameExpr.java
@@ -17,9 +17,9 @@ public class ColNameExpr extends Expr {
 	}
 
 	public ColNameExpr(String col, String tab, String schema) {
-		this.col = col.toLowerCase();
-		this.tab = (tab != null)? tab.toLowerCase() : tab;
-		this.schema = (schema != null)? schema.toLowerCase() : schema;
+		this.col = col.toLowerCase().replace("\"", "").replace("`", "");
+		this.tab = (tab != null)? tab.toLowerCase().replace("\"", "").replace("`", "") : tab;
+		this.schema = (schema != null)? schema.toLowerCase().replace("\"", "").replace("`", "") : schema;
 	}
 	
 	public static ColNameExpr from(String expr) {
@@ -52,20 +52,18 @@ public class ColNameExpr extends Expr {
 	@Override
 	public String toString() {
 		if (tab == null) {
+			return String.format("%s", quote(col));
+		} else {
+			return String.format("%s.%s", quote(tab), quote(col));
+		}
+	}
+	
+	public String getText() {
+		if (tab == null) {
 			return String.format("%s", col);
 		} else {
 			return String.format("%s.%s", tab, col);
 		}
-//		
-//		if (schema == null) {
-//			if (tab == null) {
-//				return String.format("%s", col);
-//			} else {
-//				return String.format("%s.%s", tab, col);
-//			}
-//		} else {
-//			return String.format("%s.%s.%s", schema, tab, col);
-//		}
 	}
 	
 	@Override

--- a/core/src/main/java/edu/umich/verdict/relation/expr/Expr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/Expr.java
@@ -52,9 +52,18 @@ public abstract class Expr {
 	
 //	public abstract String toString(VerdictContext vc);
 	
+	// to Sql String; use getText() to get the pure string representation.
 	@Override
 	public String toString() {
 		return "Expr Base";
+	}
+	
+	public static String quote(String s) {
+		return String.format("`%s`", s);
+	}
+	
+	public String getText() {
+		return toString();
 	}
 	
 	public Expr accept(ExprModifier v) {

--- a/core/src/main/java/edu/umich/verdict/relation/expr/FuncExpr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/FuncExpr.java
@@ -19,7 +19,7 @@ public class FuncExpr extends Expr {
 	public enum FuncName {
 		COUNT, SUM, AVG, COUNT_DISTINCT, IMPALA_APPROX_COUNT_DISTINCT,
 		ROUND, MAX, MIN, FLOOR, CEIL, EXP, LN, LOG10, LOG2, SIN, COS, TAN,
-		SIGN, RAND, UNIX_TIMESTAMP,
+		SIGN, RAND, UNIX_TIMESTAMP, FNV_HASH, ABS, STDDEV, SQRT,
 		UNKNOWN
 	}
 	
@@ -41,29 +41,37 @@ public class FuncExpr extends Expr {
 			.put("SIGN", FuncName.SIGN)
 			.put("RAND", FuncName.RAND)
 			.put("UNIX_TIMESTAMP", FuncName.UNIX_TIMESTAMP)
+			.put("FNV_HASH", FuncName.FNV_HASH)
+			.put("ABS", FuncName.ABS)
+			.put("STDDEV", FuncName.STDDEV)
+			.put("SQRT", FuncName.SQRT)
 			.build();
 
 	protected static Map<FuncName, String> functionPattern = ImmutableMap.<FuncName, String>builder()
-			.put(FuncName.COUNT,  "COUNT(%s)")
-			.put(FuncName.SUM, "SUM(%s)")
-			.put(FuncName.AVG, "AVG(%s)")
-			.put(FuncName.COUNT_DISTINCT, "COUNT(DISTINCT %s)")
-			.put(FuncName.IMPALA_APPROX_COUNT_DISTINCT, "NDV(%s)")
-			.put(FuncName.ROUND, "ROUND(%s)")
-			.put(FuncName.MIN, "MIN(%s)")
-			.put(FuncName.MAX, "MAX(%s)")
-			.put(FuncName.FLOOR, "FLOOR(%s)")
-			.put(FuncName.CEIL, "CEIL(%s)")
-			.put(FuncName.EXP, "EXP(%s)")
-			.put(FuncName.LN, "LN(%s)")
-			.put(FuncName.LOG10, "LOG10(%s)")
-			.put(FuncName.LOG2, "LOG2(%s)")
-			.put(FuncName.SIN, "SIN(%s)")
-			.put(FuncName.COS, "COS(%s)")
-			.put(FuncName.TAN, "TAN(%s)")
-			.put(FuncName.SIGN, "SIGN(%s)")
-			.put(FuncName.RAND, "RAND(%s)")
-			.put(FuncName.UNIX_TIMESTAMP, "UNIX_TIMESTAMP(%s)")
+			.put(FuncName.COUNT,  "count(%s)")
+			.put(FuncName.SUM, "sum(%s)")
+			.put(FuncName.AVG, "avg(%s)")
+			.put(FuncName.COUNT_DISTINCT, "count(distinct %s)")
+			.put(FuncName.IMPALA_APPROX_COUNT_DISTINCT, "ndv(%s)")
+			.put(FuncName.ROUND, "round")
+			.put(FuncName.MIN, "min(%s)")
+			.put(FuncName.MAX, "max(%s)")
+			.put(FuncName.FLOOR, "floor(%s)")
+			.put(FuncName.CEIL, "ceil(%s)")
+			.put(FuncName.EXP, "exp(%s)")
+			.put(FuncName.LN, "ln(%s)")
+			.put(FuncName.LOG10, "log10(%s)")
+			.put(FuncName.LOG2, "log2(%s)")
+			.put(FuncName.SIN, "sin(%s)")
+			.put(FuncName.COS, "cos(%s)")
+			.put(FuncName.TAN, "tan(%s)")
+			.put(FuncName.SIGN, "sign(%s)")
+			.put(FuncName.RAND, "rand(%s)")
+			.put(FuncName.UNIX_TIMESTAMP, "unix_timestamp(%s)")
+			.put(FuncName.FNV_HASH, "fnv_hash(%s)")
+			.put(FuncName.ABS, "abs(%s)")
+			.put(FuncName.STDDEV, "stddev(%s)")
+			.put(FuncName.SQRT, "sqrt(%s)")
 			.put(FuncName.UNKNOWN, "UNKNOWN(%s)")
 			.build();
 	
@@ -175,6 +183,14 @@ public class FuncExpr extends Expr {
 		return new FuncExpr(FuncName.MAX, expr);
 	}
 	
+	public static FuncExpr stddev(Expr expr) {
+		return new FuncExpr(FuncName.STDDEV, expr);
+	}
+	
+	public static FuncExpr sqrt(Expr expr) {
+		return new FuncExpr(FuncName.SQRT, expr);
+	}
+	
 	public static FuncExpr approxCountDistinct(Expr expr, VerdictContext vc) {
 		if (vc.getDbms().getName().equalsIgnoreCase("impala")) {
 			return new FuncExpr(FuncName.IMPALA_APPROX_COUNT_DISTINCT, expr);
@@ -206,8 +222,10 @@ public class FuncExpr extends Expr {
 		if (funcname.equals(FuncName.AVG) || funcname.equals(FuncName.SUM) || funcname.equals(FuncName.COUNT)
 			|| funcname.equals(FuncName.COUNT_DISTINCT)) {
 			return true;
+		} else if (expression != null) {
+			return expression.isagg();
 		} else {
 			return false;
-		}	
+		}
 	}
 }

--- a/core/src/main/java/edu/umich/verdict/relation/expr/FuncExpr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/FuncExpr.java
@@ -134,6 +134,8 @@ public class FuncExpr extends Expr {
 						fname = FuncName.COUNT;
 						expr = new StarExpr();
 					}
+				} else if (ctx.NDV() != null) {
+					fname = FuncName.IMPALA_APPROX_COUNT_DISTINCT;
 				} else {
 					fname = FuncName.UNKNOWN;
 				}

--- a/core/src/main/java/edu/umich/verdict/relation/expr/OverClause.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/OverClause.java
@@ -1,0 +1,55 @@
+package edu.umich.verdict.relation.expr;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+import com.google.common.base.Joiner;
+
+import edu.umich.verdict.VerdictSQLLexer;
+import edu.umich.verdict.VerdictSQLParser;
+import edu.umich.verdict.VerdictSQLParser.ExpressionContext;
+import edu.umich.verdict.VerdictSQLParser.Over_clauseContext;
+import edu.umich.verdict.VerdictSQLParser.Partition_by_clauseContext;
+
+public class OverClause {
+
+	protected List<Expr> partitionBy;
+	
+	public OverClause() {
+		this.partitionBy = new ArrayList<Expr>();
+	}
+	
+	public OverClause(List<Expr> partitionBy) {
+		this.partitionBy = partitionBy;
+	}
+	
+	public static OverClause from(String partitionByInString) {
+		VerdictSQLLexer l = new VerdictSQLLexer(CharStreams.fromString(partitionByInString));
+		VerdictSQLParser p = new VerdictSQLParser(new CommonTokenStream(l));
+		return from(p.over_clause());
+	}
+	
+	@Override
+	public String toString() {
+		if (partitionBy.size() > 0) {
+			return String.format("OVER (partition by %s)", Joiner.on(", ").join(partitionBy));
+		} else {
+			return "OVER ()";
+		}
+	}
+
+	public static OverClause from(Over_clauseContext over_clause) {
+		List<Expr> exprs = new ArrayList<Expr>();
+		if (over_clause.partition_by_clause() != null) {
+			Partition_by_clauseContext pctx = over_clause.partition_by_clause();
+			for (ExpressionContext ectx : pctx.expression_list().expression()) {
+				exprs.add(Expr.from(ectx));
+			}
+		}
+		return new OverClause(exprs);
+	}
+	
+}

--- a/core/src/main/java/edu/umich/verdict/relation/expr/SelectElem.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/SelectElem.java
@@ -31,7 +31,10 @@ public class SelectElem {
 	public static SelectElem from(String elem) {
 		VerdictSQLLexer l = new VerdictSQLLexer(CharStreams.fromString(elem));
 		VerdictSQLParser p = new VerdictSQLParser(new CommonTokenStream(l));
-		
+		return from(p.select_list_elem());
+	}
+	
+	public static SelectElem from(VerdictSQLParser.Select_list_elemContext ctx) {
 		VerdictSQLBaseVisitor<SelectElem> v = new VerdictSQLBaseVisitor<SelectElem>() {
 			@Override
 			public SelectElem visitSelect_list_elem(VerdictSQLParser.Select_list_elemContext ctx) {
@@ -49,7 +52,7 @@ public class SelectElem {
 			}	
 		};
 		
-		return v.visit(p.select_list_elem());
+		return v.visit(ctx);
 	}
 	
 	private static int column_alias_num = 1;

--- a/core/src/main/java/edu/umich/verdict/relation/expr/SelectElem.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/SelectElem.java
@@ -17,10 +17,14 @@ public class SelectElem {
 	
 	public SelectElem(Expr expr, String alias) {
 		this.expr = expr;
-		if (alias == null && expr.isagg()) {
-			this.alias = Optional.of(genColumnAlias());		// aggregate expressions must be aliased.
+		if (alias == null) {
+			if (expr.isagg()) {
+				this.alias = Optional.of(genColumnAlias());		// aggregate expressions must be aliased.
+			} else {
+				this.alias = Optional.fromNullable(alias);
+			}
 		} else {
-			this.alias = Optional.fromNullable(alias);
+			this.alias = Optional.fromNullable(alias.replace("\"", "").replace("`", ""));
 		}
 	}
 	
@@ -90,7 +94,7 @@ public class SelectElem {
 	@Override
 	public String toString() {
 		if (alias.isPresent()) {
-			return String.format("%s AS %s", expr.toString(), alias.get());
+			return String.format("%s AS %s", expr.toString(), Expr.quote(alias.get()));
 		} else {
 			return expr.toString();
 		}

--- a/core/src/main/java/edu/umich/verdict/relation/expr/SubqueryExpr.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/SubqueryExpr.java
@@ -1,5 +1,8 @@
 package edu.umich.verdict.relation.expr;
 
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.VerdictSQLParser;
+import edu.umich.verdict.relation.ExactRelation;
 import edu.umich.verdict.relation.Relation;
 
 public class SubqueryExpr extends Expr {
@@ -12,6 +15,10 @@ public class SubqueryExpr extends Expr {
 	
 	public static SubqueryExpr from(Relation r) {
 		return new SubqueryExpr(r);
+	}
+	
+	public static SubqueryExpr from(VerdictContext vc, VerdictSQLParser.Subquery_expressionContext ctx) {
+		return from(ExactRelation.from(vc, ctx.subquery().select_statement()));
 	}
 	
 	public Relation getSubquery() {

--- a/core/src/main/resources/default.conf
+++ b/core/src/main/resources/default.conf
@@ -15,7 +15,7 @@ verdict.meta_catalog_suffix = ""
 # Available options: nobound, subsampling, bootstrapping
 verdict.error_bound_method = subsampling
 verdict.confidence_internal_probability = 95%
-verdict.sampling_probability_column = verdict_rand
+verdict.sampling_probability_column = verdict_sampling_prob
 verdict.subsampling_partition_column_name = __vpart
 verdict.subsampling_partition_count = 100
 verdict.bootstrapping_trials = 100

--- a/core/src/main/resources/default.conf
+++ b/core/src/main/resources/default.conf
@@ -16,7 +16,8 @@ verdict.meta_catalog_suffix = ""
 verdict.error_bound_method = subsampling
 verdict.confidence_internal_probability = 95%
 verdict.sampling_probability_column = verdict_rand
-verdict.partition_column_name = verdict_partition
+verdict.subsampling_partition_column_name = __vpart
+verdict.subsampling_partition_count = 100
 verdict.bootstrapping_trials = 100
 
 # not in use currently

--- a/core/src/main/resources/default.conf
+++ b/core/src/main/resources/default.conf
@@ -5,16 +5,24 @@
 #udf_bin = /path/to/udf_bin folder accessible to DBMS
 #udf_bin_hdfs = /path/to/udf_bin folder in HDFS accessible to Impala
 
-log4j.loglevel = debug
-meta_name_table = verdict_meta_name
-meta_size_table = verdict_meta_size
+verdict.bypass = false
+verdict.loglevel = debug
+verdict.meta_name_table = verdict_meta_name
+verdict.meta_size_table = verdict_meta_size
+verdict.meta_catalog_suffix = ""
+verdict.sampling_probability_column = verdict_rand
+
+# Available options: subsampling, bootstrapping
+verdict.error_bound_method = subsampling
+verdict.confidence_internal_probability = 95%
+verdict.bootstrapping_trials = 100
+
+# not in use currently
 bootstrap_sampling_method = single_nested
 bootstrap_random_value_colname = verdict_rand
 bootstrap_multiplicity_colname = verdict_mul
-bootstrap_trial_num = 5
-bypass = false
 error_column_pattern = "err(%s) less than"
-confidence = 95%
+
 # one can set approximation_method = bootstrap
 approximation_method = analytic
 no_user_password = false

--- a/core/src/main/resources/default.conf
+++ b/core/src/main/resources/default.conf
@@ -15,7 +15,7 @@ verdict.meta_catalog_suffix = ""
 # Available options: nobound, subsampling, bootstrapping
 verdict.error_bound_method = subsampling
 verdict.confidence_internal_probability = 95%
-verdict.sampling_probability_column = verdict_sampling_prob
+verdict.sampling_probability_column = __vprob
 verdict.subsampling_partition_column_name = __vpart
 verdict.subsampling_partition_count = 100
 verdict.bootstrapping_trials = 100

--- a/core/src/main/resources/default.conf
+++ b/core/src/main/resources/default.conf
@@ -10,11 +10,13 @@ verdict.loglevel = debug
 verdict.meta_name_table = verdict_meta_name
 verdict.meta_size_table = verdict_meta_size
 verdict.meta_catalog_suffix = ""
-verdict.sampling_probability_column = verdict_rand
 
-# Available options: subsampling, bootstrapping
+
+# Available options: nobound, subsampling, bootstrapping
 verdict.error_bound_method = subsampling
 verdict.confidence_internal_probability = 95%
+verdict.sampling_probability_column = verdict_rand
+verdict.partition_column_name = verdict_partition
 verdict.bootstrapping_trials = 100
 
 # not in use currently

--- a/core/src/test/java/edu/umich/verdict/HiveAggregationIT.java
+++ b/core/src/test/java/edu/umich/verdict/HiveAggregationIT.java
@@ -37,35 +37,13 @@ public class HiveAggregationIT extends AggregationIT {
 	public static void destroy() throws VerdictException {
 		vc.destroy();
 	}
+
+	@Override
+	public void simpleAvg() throws VerdictException, SQLException {
+		// TODO Auto-generated method stub
+		super.simpleAvg();
+	}
 	
-	@Override
-	public void simpleCountDistinctUsingUniverseSample() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingUniverseSample();
-	}
-
-	@Override
-	public void simpleCountDistinctUsingUniverseSample2() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingUniverseSample2();
-	}
-
-	@Override
-	public void simpleCountDistinctUsingStratifiedSample() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingStratifiedSample();
-	}
-
-	@Override
-	public void simpleCountDistinctUsingStratifiedSample2() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingStratifiedSample2();
-	}
-
-	@Override
-	public void groupbyCountDistinctUsingUniverseSample() throws VerdictException, SQLException {
-		super.groupbyCountDistinctUsingUniverseSample();
-	}
-
-	@Override
-	public void groupbyCountDistinctUsingUniverseSample2() throws VerdictException, SQLException {
-		super.groupbyCountDistinctUsingUniverseSample2();
-	}
+	
 
 }

--- a/core/src/test/java/edu/umich/verdict/HiveSampleIT.java
+++ b/core/src/test/java/edu/umich/verdict/HiveSampleIT.java
@@ -68,4 +68,10 @@ public class HiveSampleIT extends SampleIT {
 		super.dropRecommendedSampleTest();
 	}
 
+	@Override
+	public void createUniformSampleTest() throws VerdictException {
+		// TODO Auto-generated method stub
+		super.createUniformSampleTest();
+	}
+
 }

--- a/core/src/test/java/edu/umich/verdict/ImpalaAggregationIT.java
+++ b/core/src/test/java/edu/umich/verdict/ImpalaAggregationIT.java
@@ -37,12 +37,13 @@ public class ImpalaAggregationIT extends AggregationIT {
 	public static void destroy() throws VerdictException {
 		vc.destroy();
 	}
-	
+
 	@Override
-	public void simpleAvg() throws VerdictException, SQLException {
+	public void simpleAvgUsingUniformSample() throws VerdictException, SQLException {
 		// TODO Auto-generated method stub
-		super.simpleAvg();
+		super.simpleAvgUsingUniformSample();
 	}
+	
 	
 
 }

--- a/core/src/test/java/edu/umich/verdict/ImpalaAggregationIT.java
+++ b/core/src/test/java/edu/umich/verdict/ImpalaAggregationIT.java
@@ -37,35 +37,12 @@ public class ImpalaAggregationIT extends AggregationIT {
 	public static void destroy() throws VerdictException {
 		vc.destroy();
 	}
-
+	
 	@Override
-	public void simpleCountDistinctUsingUniverseSample() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingUniverseSample();
+	public void simpleAvg() throws VerdictException, SQLException {
+		// TODO Auto-generated method stub
+		super.simpleAvg();
 	}
-
-	@Override
-	public void simpleCountDistinctUsingUniverseSample2() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingUniverseSample2();
-	}
-
-	@Override
-	public void simpleCountDistinctUsingStratifiedSample() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingStratifiedSample();
-	}
-
-	@Override
-	public void simpleCountDistinctUsingStratifiedSample2() throws VerdictException, SQLException {
-		super.simpleCountDistinctUsingStratifiedSample2();
-	}
-
-	@Override
-	public void groupbyCountDistinctUsingUniverseSample() throws VerdictException, SQLException {
-		super.groupbyCountDistinctUsingUniverseSample();
-	}
-
-	@Override
-	public void groupbyCountDistinctUsingUniverseSample2() throws VerdictException, SQLException {
-		super.groupbyCountDistinctUsingUniverseSample2();
-	}
+	
 
 }

--- a/core/src/test/java/edu/umich/verdict/ImpalaSampleIT.java
+++ b/core/src/test/java/edu/umich/verdict/ImpalaSampleIT.java
@@ -40,6 +40,11 @@ public class ImpalaSampleIT extends SampleIT {
 	}
 
 	@Override
+	public void createUniformSampleTest() throws VerdictException {
+		super.createUniformSampleTest();
+	}
+
+	@Override
 	public void createRecommendedSampleTest() throws VerdictException {
 		super.createRecommendedSampleTest();
 	}
@@ -47,6 +52,11 @@ public class ImpalaSampleIT extends SampleIT {
 	@Override
 	public void dropRecommendedSampleTest() throws VerdictException {
 		super.dropRecommendedSampleTest();
+	}
+
+	@Override
+	public void createUniverseSampleTest() throws VerdictException {
+		super.createUniverseSampleTest();
 	}
 
 	@Override

--- a/core/src/test/java/edu/umich/verdict/ImpalaSampleIT.java
+++ b/core/src/test/java/edu/umich/verdict/ImpalaSampleIT.java
@@ -48,5 +48,10 @@ public class ImpalaSampleIT extends SampleIT {
 	public void dropRecommendedSampleTest() throws VerdictException {
 		super.dropRecommendedSampleTest();
 	}
+
+	@Override
+	public void createStratifiedSampleTest() throws VerdictException {
+		super.createStratifiedSampleTest();
+	}
 	
 }

--- a/core/src/test/java/edu/umich/verdict/SampleIT.java
+++ b/core/src/test/java/edu/umich/verdict/SampleIT.java
@@ -18,7 +18,7 @@ public class SampleIT extends BaseIT {
 	
 	@Test
 	public void createStratifiedSampleTest() throws VerdictException {
-		vc.executeQuery("CREATE STRATIFIED SAMPLE OF orders ON order_dow");
+		vc.executeQuery("create stratified sample of orders ON order_dow");
 	}
 	
 	@Test

--- a/core/src/test/java/edu/umich/verdict/SampleIT.java
+++ b/core/src/test/java/edu/umich/verdict/SampleIT.java
@@ -17,6 +17,11 @@ public class SampleIT extends BaseIT {
 	}
 	
 	@Test
+	public void createUniformSampleTest() throws VerdictException {
+		vc.executeQuery("create uniform sample of orders");
+	}
+	
+	@Test
 	public void createStratifiedSampleTest() throws VerdictException {
 		vc.executeQuery("create stratified sample of orders ON order_dow");
 	}

--- a/core/src/test/java/edu/umich/verdict/relation/PrettyPrintTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/PrettyPrintTest.java
@@ -25,5 +25,11 @@ public class PrettyPrintTest {
 				+ "WHERE rand(unix_timestamp()) < (3421082 * (0.01 / (grp_size / (SELECT count(distinct order_dow) AS expr1 FROM orders))))";
 		System.out.println(Relation.prettyfySql(sql));
 	}
+	
+	@Test
+	public void ndvTest() {
+		String sql = "select ndv(user_id) from orders;";
+		System.out.println(Relation.prettyfySql(sql));
+	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/PrettyPrintTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/PrettyPrintTest.java
@@ -8,10 +8,22 @@ public class PrettyPrintTest {
 
 	@Test
 	public void selectAllTest() {
-		
 		String sql = "SELECT * FROM instacart1g.verdict_meta_size";
 		System.out.println(Relation.prettyfySql(sql));
-		
+	}
+	
+	@Test
+	public void partitionByTest() {
+		String sql = "SELECT sum(price * (1 - discount)) OVER (partition by ship_method) FROM instacart1g.verdict_meta_size";
+		System.out.println(Relation.prettyfySql(sql));
+	}
+	
+	@Test
+	public void stratifiedSampleTest() {
+		String sql = "SELECT *, (count(*) OVER (partition by order_dow) / grp_size) AS verdict_sampling_prob "
+				+ "FROM (SELECT *, count(*) OVER (partition by order_dow) AS grp_size FROM orders) AS vt8 "
+				+ "WHERE rand(unix_timestamp()) < (3421082 * (0.01 / (grp_size / (SELECT count(distinct order_dow) AS expr1 FROM orders))))";
+		System.out.println(Relation.prettyfySql(sql));
 	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/SqlToRelationUnitTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SqlToRelationUnitTest.java
@@ -2,8 +2,13 @@ package edu.umich.verdict.relation;
 
 import static org.junit.Assert.*;
 
+import java.io.FileNotFoundException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.util.Arrays;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.base.Joiner;
@@ -14,43 +19,79 @@ import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.util.StackTraceReader;
 
 public class SqlToRelationUnitTest {
+	
+	static VerdictContext vc;
+	
+	@BeforeClass
+	public static void connect() throws VerdictException, SQLException, FileNotFoundException {
+		VerdictConf conf = new VerdictConf();
+		conf.setDbms("dummy");
+		vc = new VerdictContext(conf);
+	}
 
 	@Test
-	public void singleAggregation() {
-		try {
-			VerdictConf conf = new VerdictConf();
-			conf.setDbms("dummy");
-			VerdictContext vc = new VerdictContext(conf);
-			
-			String sql = "SELECT COUNT(*) FROM orders";
-			
-			ExactRelation r = ExactRelation.from(vc, sql);
-			assertTrue(r instanceof ProjectedRelation);
-			
-			ProjectedRelation r1 = (ProjectedRelation) r; 
-			assertTrue(r1.getSource() instanceof AggregatedRelation);
-			
-			AggregatedRelation r2 = (AggregatedRelation) r1.getSource();
-			assertTrue(r2.getSource() instanceof SingleRelation);
-			
-		} catch (VerdictException e) {
-			System.out.println(StackTraceReader.stackTrace2String(e));
-			assert(false);
-		}
+	public void singleAggregationTest() {
+		String sql = "SELECT COUNT(*) FROM orders";
+
+		ExactRelation r = ExactRelation.from(vc, sql);
+		assertTrue(r instanceof ProjectedRelation);
+
+		ProjectedRelation r1 = (ProjectedRelation) r; 
+		assertTrue(r1.getSource() instanceof AggregatedRelation);
+
+		AggregatedRelation r2 = (AggregatedRelation) r1.getSource();
+		assertTrue(r2.getSource() instanceof SingleRelation);
 	}
 	
 	@Test
-	public void test2() throws VerdictException {
-		VerdictConf conf = new VerdictConf();
-		conf.setDbms("dummy");
-		VerdictContext vc = new VerdictContext(conf);
-		
-		Relation tableWithRand = SingleRelation.from(vc, "table1")
-				 .join(SingleRelation.from(vc, "table2"),
-				 	   Joiner.on(" AND ").join(Arrays.asList("col1 = col1")))
-				 .select("a, b, c, verdict_grp_size, rand(unix_timestamp()) as verdict_rand");
-		
-		System.out.println(tableWithRand.toSql());
+	public void nestedRelationTest() {
+		String sql = "select a, b, s.c, t.c "
+				+ "from (select a, b, c from mytable) s, "
+				+ "     t "
+				+ "where s.col = t.col";
+
+		ExactRelation r = ExactRelation.from(vc, sql);
+		System.out.println(r.toSql());
+	}
+	
+	@Test
+	public void nestedRelationTest2() {
+		String sql = "select col1, col2, s.col3, t.col3 "
+				+ "from (select col1, col2, col3 from mytable) s, "
+				+ "     t AS t1 "
+				+ "where s.col = t1.col";
+
+		ExactRelation r = ExactRelation.from(vc, sql);
+		System.out.println(r);
+	}
+	
+	@Test
+	public void nestedRelationWithSubqueryTest() {
+		String sql = "select col1, col2, s.col3, t.col3 "
+				+ "from (select col1, col2, col3 from mytable) s, "
+				+ "     t AS t1 "
+				+ "where s.col = t1.col AND "
+				+ "      t.col1 > (select avg(col1) from t)";
+
+		ExactRelation r = ExactRelation.from(vc, sql);
+		System.out.println(r);
+		System.out.println(r.toSql());
+		System.out.println(Relation.prettyfySql(r.toSql()));
+	}
+	
+	@Test
+	public void multipleJoinTest() {
+		String sql = "select g, count(*) "
+			 	   + "from t1, t2, t3, t4 "
+			 	   + "where t1.col = t2.col AND "
+			 	   + "      t1.col2 = t3.col2 AND "
+			 	   + "      t1.col3 = t4.col3 AND "
+			 	   + "      t1.col4 = 'air'";
+
+		ExactRelation r = ExactRelation.from(vc, sql);
+		System.out.println(r);
+		System.out.println(r.toSql());
+		System.out.println(Relation.prettyfySql(r.toSql()));
 	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/SubsamplingMultipleAggregationTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SubsamplingMultipleAggregationTest.java
@@ -1,0 +1,57 @@
+package edu.umich.verdict.relation;
+
+import java.sql.ResultSet;
+
+import edu.umich.verdict.VerdictConf;
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.util.ResultSetConversion;
+
+public class SubsamplingMultipleAggregationTest {
+
+	public static void main(String[] args) throws VerdictException {
+		VerdictConf conf = new VerdictConf();
+		conf.setHost("salat1.eecs.umich.edu");
+		conf.setDbms("impala");
+		conf.setPort("21050");
+		conf.setDbmsSchema("instacart1g");
+		conf.set("no_user_password", "true");
+		VerdictContext vc = new VerdictContext(conf);
+		
+		String sql;
+		ExactRelation r;
+		String converted;
+		ResultSet rs;
+		
+//		sql = "select count(distinct user_id), count(*) from orders";
+//		rs = vc.executeQuery(sql);
+//		ResultSetConversion.printResultSet(rs);
+		
+//		sql = "select count(distinct user_id), count(distinct order_id) from orders";
+//		rs = vc.executeQuery(sql);
+//		ResultSetConversion.printResultSet(rs);
+		
+//		sql = "select count(distinct user_id), count(distinct order_id), count(*) from orders";
+//		rs = vc.executeQuery(sql);
+//		ResultSetConversion.printResultSet(rs);
+		
+//		sql = "select order_dow, count(distinct user_id), count(*) from orders group by order_dow order by order_dow";
+//		rs = vc.executeQuery(sql);
+//		ResultSetConversion.printResultSet(rs);
+		
+//		sql = "select order_dow AS dow, count(distinct user_id), count(distinct order_id), count(*) from orders group by order_dow order by order_dow";
+//		rs = vc.executeQuery(sql);
+//		ResultSetConversion.printResultSet(rs);
+		
+		sql = "select dow AS dow1 from ("
+			+ "select order_dow AS dow, count(distinct user_id), count(distinct order_id), count(*) "
+			+ "from orders "
+			+ "group by order_dow "
+			+ "order by order_dow) t1";
+		rs = vc.executeQuery(sql);
+		ResultSetConversion.printResultSet(rs);
+		
+		vc.destroy();
+	}
+
+}

--- a/core/src/test/java/edu/umich/verdict/relation/SubsamplingNestedQueryTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SubsamplingNestedQueryTest.java
@@ -1,0 +1,33 @@
+package edu.umich.verdict.relation;
+
+import java.sql.ResultSet;
+
+import edu.umich.verdict.VerdictConf;
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.util.ResultSetConversion;
+
+public class SubsamplingNestedQueryTest {
+
+	public static void main(String[] args) throws VerdictException {
+		
+		VerdictConf conf = new VerdictConf();
+		conf.setHost("salat1.eecs.umich.edu");
+		conf.setDbms("impala");
+		conf.setPort("21050");
+		conf.setDbmsSchema("instacart1g");
+		conf.set("no_user_password", "true");
+		VerdictContext vc = new VerdictContext(conf);
+		
+		String sql;
+		ExactRelation r;
+		String converted;
+		ResultSet rs;
+		
+		sql = "select avg(days_since_prior) from orders where days_since_prior > (select avg(days_since_prior) from orders)";
+		r = ExactRelation.from(vc, sql);
+		rs = vc.executeQuery(sql);
+		ResultSetConversion.printResultSet(rs);
+	}
+
+}

--- a/core/src/test/java/edu/umich/verdict/relation/SubsamplingPartitionTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SubsamplingPartitionTest.java
@@ -1,0 +1,35 @@
+package edu.umich.verdict.relation;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import edu.umich.verdict.VerdictConf;
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.datatypes.SampleParam;
+import edu.umich.verdict.datatypes.TableUniqueName;
+import edu.umich.verdict.exceptions.VerdictException;
+
+public class SubsamplingPartitionTest {
+
+	@Test
+	public void SingleRelationTest() throws VerdictException {
+		VerdictConf conf = new VerdictConf();
+		conf.setHost("salat1.eecs.umich.edu");
+		conf.setDbms("impala");
+		conf.setPort("21050");
+		conf.setDbmsSchema("instacart1g");
+		conf.set("no_user_password", "true");
+		VerdictContext vc = new VerdictContext(conf);
+		
+		TableUniqueName orders = TableUniqueName.uname(vc, "orders");
+		SampleParam param = new SampleParam(orders, "uniform", 0.01, Arrays.<String>asList());
+		ExactRelation r = ApproxSingleRelation.from(vc, param).rewriteWithPartition();
+		
+		System.out.println(r.toSql());
+		
+	}
+
+}

--- a/core/src/test/java/edu/umich/verdict/relation/SubsamplingSqlConversionTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SubsamplingSqlConversionTest.java
@@ -23,7 +23,7 @@ public class SubsamplingSqlConversionTest {
 		String converted;
 		ResultSet rs;
 		
-		sql = "select avg(days_since_prior) from orders";
+		sql = "select count(*) from orders";
 		r = ExactRelation.from(vc, sql);
 		converted = r.approx().toSql();
 		System.out.println(converted);
@@ -31,7 +31,7 @@ public class SubsamplingSqlConversionTest {
 		rs = vc.executeQuery(sql);
 		ResultSetConversion.printResultSet(rs);
 		
-		sql = "select order_dow, avg(days_since_prior) from orders group by order_dow";
+		sql = "select order_dow, count(*) from orders group by order_dow order by order_dow";
 		r = ExactRelation.from(vc, sql);
 		converted = r.approx().toSql();
 		System.out.println(converted);

--- a/core/src/test/java/edu/umich/verdict/relation/SubsamplingSqlConversionTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SubsamplingSqlConversionTest.java
@@ -25,17 +25,25 @@ public class SubsamplingSqlConversionTest {
 		
 		sql = "select count(*) from orders";
 		r = ExactRelation.from(vc, sql);
-		converted = r.approx().toSql();
-		System.out.println(converted);
-		System.out.println(Relation.prettyfySql(converted));
+//		converted = r.approx().toSql();
+//		System.out.println(converted);
+//		System.out.println(Relation.prettyfySql(converted));
+		rs = vc.executeQuery(sql);
+		ResultSetConversion.printResultSet(rs);
+		
+		sql = "select sum(orders.days_since_prior) from orders";
+		r = ExactRelation.from(vc, sql);
+//		converted = r.approx().toSql();
+//		System.out.println(converted);
+//		System.out.println(Relation.prettyfySql(converted));
 		rs = vc.executeQuery(sql);
 		ResultSetConversion.printResultSet(rs);
 		
 		sql = "select order_dow, count(*) from orders group by order_dow order by order_dow";
 		r = ExactRelation.from(vc, sql);
-		converted = r.approx().toSql();
-		System.out.println(converted);
-		System.out.println(Relation.prettyfySql(converted));
+//		converted = r.approx().toSql();
+//		System.out.println(converted);
+//		System.out.println(Relation.prettyfySql(converted));
 		rs = vc.executeQuery(sql);
 		ResultSetConversion.printResultSet(rs);
 		

--- a/core/src/test/java/edu/umich/verdict/relation/SubsamplingSqlConversionTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SubsamplingSqlConversionTest.java
@@ -1,0 +1,45 @@
+package edu.umich.verdict.relation;
+
+import java.sql.ResultSet;
+
+import edu.umich.verdict.VerdictConf;
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.util.ResultSetConversion;
+
+public class SubsamplingSqlConversionTest {
+	
+	public static void main(String[] args) throws VerdictException {
+		VerdictConf conf = new VerdictConf();
+		conf.setHost("salat1.eecs.umich.edu");
+		conf.setDbms("impala");
+		conf.setPort("21050");
+		conf.setDbmsSchema("instacart1g");
+		conf.set("no_user_password", "true");
+		VerdictContext vc = new VerdictContext(conf);
+		
+		String sql;
+		ExactRelation r;
+		String converted;
+		ResultSet rs;
+		
+		sql = "select avg(days_since_prior) from orders";
+		r = ExactRelation.from(vc, sql);
+		converted = r.approx().toSql();
+		System.out.println(converted);
+		System.out.println(Relation.prettyfySql(converted));
+		rs = vc.executeQuery(sql);
+		ResultSetConversion.printResultSet(rs);
+		
+		sql = "select order_dow, avg(days_since_prior) from orders group by order_dow";
+		r = ExactRelation.from(vc, sql);
+		converted = r.approx().toSql();
+		System.out.println(converted);
+		System.out.println(Relation.prettyfySql(converted));
+		rs = vc.executeQuery(sql);
+		ResultSetConversion.printResultSet(rs);
+		
+		vc.destroy();
+	}
+
+}

--- a/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
@@ -4,12 +4,32 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import edu.umich.verdict.relation.Relation;
+
 public class ExprTest {
 
 	@Test
-	public void caseExpr() {
+	public void caseExprTest() {
 		Expr a = Expr.from("CASE WHEN a < 5 THEN 1 WHEN a < 10 THEN 2 ELSE 3 END");
-		System.out.println(a.toString());
+		assertEquals(a.toString(), "(CASE WHEN a < 5 THEN 1 WHEN a < 10 THEN 2 ELSE 3 END)");
+	}
+	
+	@Test
+	public void partitonExprTest() {
+		Expr a = Expr.from("count(*) over (partition by order_dow)");
+		assertEquals(a.toString(), "count(*) OVER (partition by order_dow)");
+		
+		Expr b = Expr.from("count(*) over ()");
+		assertEquals(b.toString(), "count(*) OVER ()");
+		
+		Expr c = Expr.from("sum(prices * (1 - discount)) over (partition by ship_method)");
+		assertEquals(c.toString(), "sum((prices * (1 - discount))) OVER (partition by ship_method)");
+	}
+	
+	@Test
+	public void matheFuncTest() {
+		Expr a = Expr.from("round(rand(unix_timestamp())*100)%100");
+		assertEquals(a.toString(), "(round((rand(unix_timestamp()) * 100)) % 100)");
 	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
@@ -31,12 +31,18 @@ public class ExprTest {
 	}
 	
 	@Test
-	public void matheFuncTest() {
+	public void mathFuncTest() {
 		Expr a = Expr.from("round(rand(unix_timestamp())*100)%100");
 		assertEquals(a.toString(), "(round((rand(unix_timestamp()) * 100)) % 100)");
 		
 		a = Expr.from("ndv(user_id)");
 		assertEquals(a.toString(), "ndv(user_id)");
+	}
+	
+	@Test
+	public void castExprTest() {
+		Expr a = Expr.from("abs(fnv_hash(cast(user_id as string)))%1000000");
+		System.out.println(a.toString());
 	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
@@ -24,12 +24,19 @@ public class ExprTest {
 		
 		Expr c = Expr.from("sum(prices * (1 - discount)) over (partition by ship_method)");
 		assertEquals(c.toString(), "sum((prices * (1 - discount))) OVER (partition by ship_method)");
+		
+		Expr d = Expr.from("count(*) over (partition by order_dow, __vpart)");
+		System.out.println(d);
+//		assertEquals(b.toString(), "count(*) OVER ()");
 	}
 	
 	@Test
 	public void matheFuncTest() {
 		Expr a = Expr.from("round(rand(unix_timestamp())*100)%100");
 		assertEquals(a.toString(), "(round((rand(unix_timestamp()) * 100)) % 100)");
+		
+		a = Expr.from("ndv(user_id)");
+		assertEquals(a.toString(), "ndv(user_id)");
 	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/expr/ParsingTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/expr/ParsingTest.java
@@ -1,0 +1,36 @@
+package edu.umich.verdict.relation.expr;
+
+import static org.junit.Assert.*;
+
+import java.io.FileNotFoundException;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import edu.umich.verdict.VerdictConf;
+import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.Relation;
+import edu.umich.verdict.relation.SingleRelation;
+
+public class ParsingTest {
+	
+	@Test
+	public void test() throws VerdictException {
+		VerdictConf conf = new VerdictConf();
+		conf.setDbms("dummy");
+		VerdictContext vc = new VerdictContext(conf);
+		
+		Relation r = SingleRelation.from(vc, "orders")
+					 .where(String.format("abs(fnv_hash(%s)) %% 10000 <= %.4f", "order_dow", 0.01*10000))
+					 .select("*, round(rand(unix_timestamp())*100)%100 AS " + "verdict_partition");
+		String sql = r.toSql();
+		
+		System.out.println(sql);
+		
+		System.out.println(Relation.prettyfySql(sql));
+	}
+
+}

--- a/core/src/test/java/edu/umich/verdict/relation/expr/SelectElemTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/expr/SelectElemTest.java
@@ -10,5 +10,14 @@ public class SelectElemTest {
 	public void starTest() {
 		SelectElem.from("*");
 	}
-
+	
+	@Test
+	public void randExprTest() {
+		SelectElem e = SelectElem.from("mod(rand(unix_timestamp()), 100) * 100 AS __vpart");
+		System.out.println(e.toString());
+		
+		e = SelectElem.from("(rand(unix_timestamp()) * 100) % 100 AS __vpart");
+		System.out.println(e.toString());
+	}
+	
 }


### PR DESCRIPTION
## Subsampling-based Error Estimation

By default, not Verdict outputs mean estimates and their expected errors for `count`, `sum`, `avg`, and `count(distinct ...)` queries. The queries can include `group by`, `order by`, `limit`, and derived tables. Comparisons using subqueries are not supported yet.

## Sample Creation

All samples include random partition numbers `__vpart` and per-tuple sampling probability `__vprob`. The `__vpart` column is used for subsampling.
