### PR TITLE
column names starting with underscores are properly handled in Hive

### DIFF
--- a/core/src/main/java/edu/umich/verdict/dbms/DbmsHive.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/DbmsHive.java
@@ -120,7 +120,8 @@ public class DbmsHive extends DbmsImpala {
 	
 	@Override
 	public String modOfHash(String col, int mod) {
-		return String.format("pmod(conv(substr(md5(cast(%s AS string)),17,16),16,10), %d)", col, mod);
+//		return String.format("pmod(conv(substr(md5(cast(%s AS string)),17,16),16,10), %d)", col, mod);
+		return String.format("pmod(conv(substr(md5(%s),17,16),16,10), %d)", col, mod);
 	}
 
 	@Override

--- a/core/src/main/java/edu/umich/verdict/dbms/DbmsImpala.java
+++ b/core/src/main/java/edu/umich/verdict/dbms/DbmsImpala.java
@@ -92,6 +92,7 @@ public class DbmsImpala extends Dbms {
 					randomPartitionColumn());										 // attach partition number
 		String sql = String.format("create table %s AS ", param.sampleTableName()) + sampled.toSql();
 		VerdictLogger.debug(this, "The query used for creating a uniform random sample:");
+//		VerdictLogger.debug(sql);
 		VerdictLogger.debugPretty(this, Relation.prettyfySql(sql), "  ");
 		
 		executeUpdate(sql);

--- a/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
@@ -95,8 +95,22 @@ public abstract class ExactRelation extends Relation {
 	}
 	
 	public ExactRelation select(String elems) {
-		String[] tokens = elems.split(",");
-		return select(Arrays.asList(tokens));
+		VerdictSQLLexer l = new VerdictSQLLexer(CharStreams.fromString(elems));
+		VerdictSQLParser p = new VerdictSQLParser(new CommonTokenStream(l));
+		return select(p.select_list());
+	}
+	
+	public ExactRelation select(VerdictSQLParser.Select_listContext ctx) {
+		VerdictSQLBaseVisitor<List<SelectElem>> elemVisitor = new VerdictSQLBaseVisitor<List<SelectElem>>() {
+			private List<SelectElem> selectElems = new ArrayList<SelectElem>();
+			@Override
+			public List<SelectElem> visitSelect_list_elem(VerdictSQLParser.Select_list_elemContext ctx) {
+				selectElems.add(SelectElem.from(ctx));
+				return selectElems;
+			}
+		};
+		List<SelectElem> selectElems = elemVisitor.visit(ctx);
+		return new ProjectedRelation(vc, this, selectElems);
 	}
 	
 	/*

--- a/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ProjectedRelation.java
@@ -57,15 +57,15 @@ public class ProjectedRelation extends ExactRelation {
 	protected String selectSql() {
 		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT ");
-		List<String> elemWithAlias = new ArrayList<String>();
-		for (SelectElem e : elems) {
-			if (e.getAlias() != null) {
-				elemWithAlias.add(String.format("%s AS %s", e.getExpr(), e.getAlias()));
-			} else {
-				elemWithAlias.add(e.getExpr().toString());
-			}
-		}
-		sql.append(Joiner.on(", ").join(elemWithAlias));
+//		List<String> elemWithAlias = new ArrayList<String>();
+//		for (SelectElem e : elems) {
+//			if (e.getAlias() != null) {
+//				elemWithAlias.add(String.format("%s AS %s", e.getExpr(), e.getAlias()));
+//			} else {
+//				elemWithAlias.add(e.getExpr().toString());
+//			}
+//		}
+		sql.append(Joiner.on(", ").join(elems));
 		return sql.toString();
 	}
 

--- a/core/src/main/java/edu/umich/verdict/relation/expr/SelectElem.java
+++ b/core/src/main/java/edu/umich/verdict/relation/expr/SelectElem.java
@@ -24,7 +24,7 @@ public class SelectElem {
 				this.alias = Optional.fromNullable(alias);
 			}
 		} else {
-			this.alias = Optional.fromNullable(alias.replace("\"", "").replace("`", ""));
+			setAlias(alias);
 		}
 	}
 	
@@ -84,7 +84,7 @@ public class SelectElem {
 	}
 	
 	public void setAlias(String alias) {
-		this.alias = Optional.of(alias);
+		this.alias = Optional.of(alias.replace("\"", "").replace("`", ""));
 	}
 	
 	public boolean isagg() {

--- a/core/src/test/java/edu/umich/verdict/HiveAggregationIT.java
+++ b/core/src/test/java/edu/umich/verdict/HiveAggregationIT.java
@@ -39,11 +39,9 @@ public class HiveAggregationIT extends AggregationIT {
 	}
 
 	@Override
-	public void simpleAvg() throws VerdictException, SQLException {
+	public void simpleAvgUsingUniverseSample() throws VerdictException, SQLException {
 		// TODO Auto-generated method stub
-		super.simpleAvg();
+		super.simpleAvgUsingUniverseSample();
 	}
-	
-	
 
 }

--- a/core/src/test/java/edu/umich/verdict/ImpalaAggregationIT.java
+++ b/core/src/test/java/edu/umich/verdict/ImpalaAggregationIT.java
@@ -39,10 +39,11 @@ public class ImpalaAggregationIT extends AggregationIT {
 	}
 
 	@Override
-	public void simpleAvgUsingUniformSample() throws VerdictException, SQLException {
+	public void simpleAvgUsingUniverseSample() throws VerdictException, SQLException {
 		// TODO Auto-generated method stub
-		super.simpleAvgUsingUniformSample();
+		super.simpleAvgUsingUniverseSample();
 	}
+
 	
 	
 

--- a/core/src/test/java/edu/umich/verdict/impala/ImpalaCreateSampleTest.java
+++ b/core/src/test/java/edu/umich/verdict/impala/ImpalaCreateSampleTest.java
@@ -8,13 +8,14 @@ public class ImpalaCreateSampleTest {
 
 	public static void main(String[] args) throws VerdictException {
 		VerdictConf conf = new VerdictConf();
+		conf.setHost("salat1.eecs.umich.edu");
 		conf.setDbms("impala");
 		conf.setPort("21050");
 		conf.setDbmsSchema("instacart1g");
 		conf.set("no_user_password", "true");
 
 		VerdictContext vc = new VerdictContext(conf);
-		vc.executeQuery("create stratified sample of orders on order_dow");
+		vc.executeQuery("create uniform sample of orders");
 		vc.destroy();
 		System.out.println("Done");
 	}

--- a/core/src/test/java/edu/umich/verdict/relation/ApproxSqlTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/ApproxSqlTest.java
@@ -1,9 +1,13 @@
 package edu.umich.verdict.relation;
 
 import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.List;
 
 import edu.umich.verdict.VerdictConf;
 import edu.umich.verdict.VerdictContext;
+import edu.umich.verdict.datatypes.SampleParam;
+import edu.umich.verdict.datatypes.TableUniqueName;
 import edu.umich.verdict.exceptions.VerdictException;
 import edu.umich.verdict.util.ResultSetConversion;
 
@@ -11,43 +15,23 @@ public class ApproxSqlTest {
 
 	public static void main(String[] args) throws VerdictException {
 		VerdictConf conf = new VerdictConf();
-		conf.setDbms("impala");
-		conf.setPort("21050");
+		conf.setHost("salat1.eecs.umich.edu");
+		conf.setDbms("hive2");
+		conf.setPort("10000");
 		conf.setDbmsSchema("instacart1g");
 		conf.set("no_user_password", "true");
 		VerdictContext vc = new VerdictContext(conf);
 		
-//		String sql = "select order_hour_of_day, count(distinct product_id), count(*)"
-//				+ " from order_products, orders"
-//				+ " where order_products.order_id = orders.order_id"
-//				+ "   AND order_dow = 0 or order_dow = 1"
-//				+ " group by order_hour_of_day"
-//				+ " order by order_hour_of_day asc";
+//		testSimpleAvgFor("orders", "days_since_prior", "universe", Arrays.<String>asList("order_id"));
+		String tableName = "orders";
+		String sampleType = "universe";
+		String aggCol = "days_since_prior";
+		List<String> sampleColumns = Arrays.<String>asList("order_id");
+		double samplingRatio = 0.1;
 		
-//		String sql = "select order_dow, count(*) "
-//				+ "from orders "
-//				+ "group by order_dow "
-//				+ "order by order_dow asc";
-		
-//		String sql = "select count(*) "
-//				+ "from orders";
-		
-		String sql = "select avg(days_since_prior) "
-				+ "from orders";
-		
-//		String sql = "select count(*), count(distinct user_id), count(distinct order_id) "
-//				+ "from orders";
-//				+ "where order_dow = 0 OR order_dow = 1 ";
-		
-//		String sql = "select count(*), count(distinct user_id), count(distinct orders.order_id) "
-//				+ "from order_products, orders "
-//				+ "where order_products.order_id = orders.order_id "
-//				+ " AND (order_dow = 0 OR order_dow = 1) ";
-		
-		ExactRelation r = ExactRelation.from(vc, sql);
-		ApproxRelation a = r.approx();
-		ResultSet rs = a.collectResultSet();
-		ResultSetConversion.printResultSet(rs);
+		TableUniqueName originalTable = TableUniqueName.uname(vc, tableName);
+		ApproxRelation r = ApproxSingleRelation.from(vc, new SampleParam(originalTable, sampleType, samplingRatio, sampleColumns));
+		r.avg(aggCol).collectResultSet();
 		
 		vc.destroy();
 	}

--- a/core/src/test/java/edu/umich/verdict/relation/SqlToRelationUnitTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/SqlToRelationUnitTest.java
@@ -16,6 +16,7 @@ import com.google.common.base.Joiner;
 import edu.umich.verdict.VerdictConf;
 import edu.umich.verdict.VerdictContext;
 import edu.umich.verdict.exceptions.VerdictException;
+import edu.umich.verdict.relation.expr.SelectElem;
 import edu.umich.verdict.util.StackTraceReader;
 
 public class SqlToRelationUnitTest {
@@ -92,6 +93,20 @@ public class SqlToRelationUnitTest {
 		System.out.println(r);
 		System.out.println(r.toSql());
 		System.out.println(Relation.prettyfySql(r.toSql()));
+	}
+	
+	@Test
+	public void selectFunctionsWithCommaTest() {
+		ExactRelation r = SingleRelation.from(vc, "mytable");
+		r = r.select("a, b, c, pmod(cast(user_id as string), 100) AS __vpart");
+		System.out.println(r.toSql());
+	}
+	
+	@Test
+	public void selectFunctionsWithCommaTest2() {
+		ExactRelation r = SingleRelation.from(vc, "mytable");
+		r = r.select("*, 1 AS one, count(*) OVER () AS `__total_size`");
+		System.out.println(r.toSql());
 	}
 
 }

--- a/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
+++ b/core/src/test/java/edu/umich/verdict/relation/expr/ExprTest.java
@@ -44,5 +44,11 @@ public class ExprTest {
 		Expr a = Expr.from("abs(fnv_hash(cast(user_id as string)))%1000000");
 		System.out.println(a.toString());
 	}
+	
+	@Test
+	public void hiveHashTest() {
+		Expr a = Expr.from("pmod(conv(substr(md5(cast(user_id AS string)),17,16),16,10), 100)");
+		System.out.println(a.toString());
+	}
 
 }


### PR DESCRIPTION
This is a simple bug fix. Passed sample creation and aggregation tests in Impala. Passed aggregation tests in Hive.