### PR TITLE
Fixes for issue #116

### DIFF
--- a/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/ExactRelation.java
@@ -777,7 +777,7 @@ class RelationGen extends VerdictSQLBaseVisitor<ExactRelation> {
         // is null" are not correctly recognized.
         // Support such general join expressions is a TODO item.
         ExactRelation joinedTabeSource = null;
-        while (where != null && tableSources.size() > 1) {
+        while (where != null && tableSources.size() > 0) {
             Pair<Cond, Pair<ExactRelation, ExactRelation>> joinCondAndTabName = where
                     .searchForJoinCondition(tableSources);
             if (joinCondAndTabName == null) {

--- a/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
+++ b/core/src/main/java/edu/umich/verdict/relation/JoinedRelation.java
@@ -195,6 +195,28 @@ public class JoinedRelation extends ExactRelation {
         return c;
     }
 
+    public boolean containsRelation(ExactRelation r, String tab) {
+        if (source1 instanceof SingleRelation) {
+            if (source1.getAlias().equals(tab)) {
+                return true;
+            }
+        } else if (source1 instanceof JoinedRelation) {
+            JoinedRelation jr = (JoinedRelation) source1;
+            boolean isContain = jr.containsRelation(r, tab);
+            if (isContain) return true;
+        }
+        if (source2 instanceof SingleRelation) {
+            if (source2.getAlias().equals(tab)) {
+                return true;
+            }
+        } else if (source2 instanceof JoinedRelation) {
+            JoinedRelation jr = (JoinedRelation) source2;
+            boolean isContain = jr.containsRelation(r, tab);
+            if (isContain) return true;
+        }
+        return false;
+    }
+
     /*
      * Approx
      */

--- a/core/src/main/java/edu/umich/verdict/relation/condition/AndCond.java
+++ b/core/src/main/java/edu/umich/verdict/relation/condition/AndCond.java
@@ -64,6 +64,18 @@ public class AndCond extends Cond {
         return j;
     }
 
+    // dyoon: Extracts join conditions from the current AndCond.
+    // This looks a duplicate of searchForJoinCondition, but its implementation under CompCond
+    // differs from that of searchForJoinCondition.
+    @Override
+    public Pair<Cond, Pair<ExactRelation, ExactRelation>> extractJoinCondition(List<ExactRelation> tableSources) {
+        Pair<Cond, Pair<ExactRelation, ExactRelation>> j = null;
+        j = left.extractJoinCondition(tableSources);
+        if (j == null)
+            j = right.extractJoinCondition(tableSources);
+        return j;
+    }
+
     @Override
     public Cond remove(Cond j) {
         if (left.equals(j)) {

--- a/core/src/main/java/edu/umich/verdict/relation/condition/CompCond.java
+++ b/core/src/main/java/edu/umich/verdict/relation/condition/CompCond.java
@@ -129,6 +129,36 @@ public class CompCond extends Cond {
         return null;
     }
 
+    // dyoon: currently, this function actually replace searchForJoinCondition.
+    // After we ensure that searchForJoinCondition is no longer needed. We should
+    // replace it with this function.
+    /**
+     * Extracts join relations if equal operator was used for an inner join.
+     * @param tableSources
+     * @return a pair of Cond operator and a pair of left and right join tables.
+     * returns null if it is not an inner join.
+     */
+    @Override
+    public Pair<Cond, Pair<ExactRelation, ExactRelation>> extractJoinCondition(
+            List<ExactRelation> tableSources) {
+        if (compOp.equals("=")) {
+            if (left instanceof ColNameExpr && right instanceof ColNameExpr) {
+                String leftTab = ((ColNameExpr) left).getTab();
+                String rightTab = ((ColNameExpr) right).getTab();
+                ExactRelation r1 = findSourceContaining(tableSources, leftTab);
+                ExactRelation r2 = findSourceContaining(tableSources, rightTab);
+
+                String leftOriginalName = getOriginalTableName(tableSources, leftTab);
+                String rightOriginalName = getOriginalTableName(tableSources, rightTab);
+                if (r2 != null && leftOriginalName != null && rightOriginalName != null &&
+                        !leftOriginalName.equals(rightOriginalName)) {
+                    return Pair.of((Cond) this, Pair.of(r1, r2));
+                }
+            }
+        }
+        return null;
+    }
+
     private String getOriginalTableName(List<ExactRelation> tableSources, String alias) {
         for (ExactRelation r : tableSources) {
             String name = getOriginalTableName(r, alias);

--- a/core/src/main/java/edu/umich/verdict/relation/condition/CompCond.java
+++ b/core/src/main/java/edu/umich/verdict/relation/condition/CompCond.java
@@ -90,11 +90,20 @@ public class CompCond extends Cond {
 
                 if (doesRelationContain(r1, leftTab)) {
                     r2 = findSourceContaining(tableSources, rightTab);
+                    if (r2 != null && r2 instanceof JoinedRelation) {
+                        r2 = findSingleRelation(r2, rightTab);
+                    }
                 } else if (doesRelationContain(r1, rightTab)) {
                     r2 = findSourceContaining(tableSources, leftTab);
+                    if (r2 != null && r2 instanceof JoinedRelation) {
+                        r2 = findSingleRelation(r2, leftTab);
+                    }
                 }
 
-                if (r2 != null && r1 != r2) {
+                String leftOriginalName = getOriginalTableName(tableSources, leftTab);
+                String rightOriginalName = getOriginalTableName(tableSources, rightTab);
+                if (r2 != null && leftOriginalName != null && rightOriginalName != null &&
+                        !leftOriginalName.equals(rightOriginalName)) {
                     return Pair.of((Cond) this, Pair.of(r1, r2));
                 }
 
@@ -119,6 +128,54 @@ public class CompCond extends Cond {
         }
         return null;
     }
+
+    private String getOriginalTableName(List<ExactRelation> tableSources, String alias) {
+        for (ExactRelation r : tableSources) {
+            String name = getOriginalTableName(r, alias);
+            if (name != null) return name;
+        }
+        return null;
+    }
+
+    private String getOriginalTableName(ExactRelation r, String alias) {
+        if (r instanceof SingleRelation) {
+            if (r.getAlias().equals(alias)) {
+                SingleRelation sr = (SingleRelation) r;
+                return sr.getTableName().fullyQuantifiedName();
+            }
+        }
+        else if (r instanceof JoinedRelation) {
+            String result = getOriginalTableName(((JoinedRelation) r).getLeftSource(), alias);
+            if (result == null) {
+                result = getOriginalTableName(((JoinedRelation) r).getRightSource(), alias);
+            }
+            return result;
+        }
+        else if (r instanceof ProjectedRelation) {
+            ProjectedRelation pr = (ProjectedRelation) r;
+            return getOriginalTableName(pr.getSource(), alias);
+        }
+        else if (r instanceof AggregatedRelation) {
+            AggregatedRelation ar = (AggregatedRelation) r;
+            return getOriginalTableName(ar.getSource(), alias);
+        }
+        return null;
+    }
+
+    private ExactRelation findSingleRelation(ExactRelation r, String tab) {
+        if (r instanceof SingleRelation) {
+            if (r.getAlias().equals(tab)) {
+                return r;
+            }
+        } else if (r instanceof JoinedRelation) {
+            JoinedRelation jr = (JoinedRelation) r;
+            ExactRelation res = this.findSingleRelation(jr.getLeftSource(), tab);
+            if (res != null) return res;
+            else return this.findSingleRelation(jr.getRightSource(), tab);
+        }
+        return null;
+    }
+
 
     private ExactRelation findSourceContaining(List<ExactRelation> tableSources, String tab) {
         for (ExactRelation r : tableSources) {

--- a/core/src/main/java/edu/umich/verdict/relation/condition/Cond.java
+++ b/core/src/main/java/edu/umich/verdict/relation/condition/Cond.java
@@ -63,6 +63,13 @@ public abstract class Cond {
         return null;
     }
 
+    /**
+     * Extract first join operation found in the Cond.
+     */
+    public Pair<Cond, Pair<ExactRelation, ExactRelation>> extractJoinCondition(List<ExactRelation> tableSources) {
+        return null;
+    }
+
     public Cond remove(Cond j) {
         return this;
     }


### PR DESCRIPTION
Fixes a number of issues with parsing inner joins from WHERE clause:

1. Inner join detection from WHERE clause is no longer dependent on the order of tables under FROM. Previously, it was possible to get two different results for (SELECT ... FROM A,B,C) and (SELECT ... FROM C,B,A).
2. It fixes the issue where it failed to parse every inner join in the WHERE clause (issue #116).
3. It now correctly parses multi-column inner joins.

I would like @pyongjoo to review this commit (if he has time) as this contains a substantial amount of changes that are critical to VerdictDB's operation. I will merge this commit afterwards or early next week.

FYI, the sample query in #116 now results in:

```
LimitedRelation(vt22) [100]
  OrderedRelation(vt22) [i_item_id ASC, i_item_desc ASC, s_state ASC]
    AggregatedRelation(vt22) [vt12.`i_item_id` AS `i_item_id`, vt12.`i_item_desc` AS `i_item_desc`, vt11.`s_state` AS `s_state`, count(*) AS `store_sales_quantitycount`, avg(vt5.`ss_quantity`) AS `store_sales_quantityave`, stddev_samp(vt5.`ss_quantity`) AS `store_sales_quantitystdev`, (stddev_samp(`ss_quantity`) / avg(`ss_quantity`)) AS `store_sales_quantitycov`, count(*) AS `as_store_returns_quantitycount`, avg(vt6.`sr_return_quantity`) AS `as_store_returns_quantityave`, stddev_samp(vt6.`sr_return_quantity`) AS `as_store_returns_quantitystdev`, (stddev_samp(`sr_return_quantity`) / avg(`sr_return_quantity`)) AS `store_returns_quantitycov`, count(*) AS `catalog_sales_quantitycount`, avg(vt7.`cs_quantity`) AS `catalog_sales_quantityave`, (stddev_samp(`cs_quantity`) / avg(`cs_quantity`)) AS `catalog_sales_quantitystdev`, (stddev_samp(`cs_quantity`) / avg(`cs_quantity`)) AS `catalog_sales_quantitycov`]
      GroupedRelation(vt7-d3-vt5-d1-vt11-vt12-vt6-d2) [vt12.`i_item_id`, vt12.`i_item_desc`, vt11.`s_state`]
        FilteredRelation(vt7-d3-vt5-d1-vt11-vt12-vt6-d2) [((d1.`d_quarter_name` = '2000Q1') AND (d2.`d_quarter_name` IN ('2000Q1', '2000Q2', '2000Q3'))) AND (d3.`d_quarter_name` IN ('2000Q1', '2000Q2', '2000Q3'))]
          JoinedRelation(vt7-d3-vt5-d1-vt11-vt12-vt6-d2) [(vt6.`sr_returned_date_sk`,d2.`d_date_sk`)]
            JoinedRelation(vt7-d3-vt5-d1-vt11-vt12-vt6) [(vt6.`sr_customer_sk`,vt7.`cs_bill_customer_sk`), (vt6.`sr_item_sk`,vt7.`cs_item_sk`)]
              JoinedRelation(vt7-d3) [(vt7.`cs_sold_date_sk`,d3.`d_date_sk`)]
                SingleRelation(tpcds_bin_partitioned_orc_2.catalog_sales, vt7)
                SingleRelation(tpcds_bin_partitioned_orc_2.date_dim, d3)
              JoinedRelation(vt5-d1-vt11-vt12-vt6) [(vt5.`ss_customer_sk`,vt6.`sr_customer_sk`), (vt5.`ss_item_sk`,vt6.`sr_item_sk`), (vt5.`ss_ticket_number`,vt6.`sr_ticket_number`)]
                JoinedRelation(vt5-d1-vt11-vt12) [(vt12.`i_item_sk`,vt5.`ss_item_sk`)]
                  JoinedRelation(vt5-d1-vt11) [(vt11.`s_store_sk`,vt5.`ss_store_sk`)]
                    JoinedRelation(vt5-d1) [(d1.`d_date_sk`,vt5.`ss_sold_date_sk`)]
                      SingleRelation(tpcds_bin_partitioned_orc_2.store_sales, vt5)
                      SingleRelation(tpcds_bin_partitioned_orc_2.date_dim, d1)
                    SingleRelation(tpcds_bin_partitioned_orc_2.store, vt11)
                  SingleRelation(tpcds_bin_partitioned_orc_2.item, vt12)
                SingleRelation(tpcds_bin_partitioned_orc_2.store_returns, vt6)
            SingleRelation(tpcds_bin_partitioned_orc_2.date_dim, d2)
```

We can see that JoinedRelations are correctly constructed with multi-columns.